### PR TITLE
Refactor leaks

### DIFF
--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -1,6 +1,5 @@
 #include "aboutdialog.hpp"
 
-#include <QCoreApplication>
 #include <QDialog>
 #include <QLabel>
 #include <QObject>
@@ -12,12 +11,14 @@
 AboutDialog::AboutDialog(const QVariant &task_version, QWidget *parent)
     : QDialog(parent)
 {
+    setWindowTitle(tr("About"));
     initUI(task_version);
 }
 
+AboutDialog::~AboutDialog() = default;
+
 void AboutDialog::initUI(const QVariant &task_version)
 {
-    setWindowTitle(QCoreApplication::applicationName() + " - About");
 
     const QString version = QString("%1.%2.%3")
                                 .arg(QString::number(QTASK_VERSION_MAJOR),
@@ -25,30 +26,31 @@ void AboutDialog::initUI(const QVariant &task_version)
                                      QString::number(QTASK_VERSION_PATCH));
 
     const QString info =
-        QString("<html><style>a { color: blue; text-decoration: none; "
-                "}</style><body>"
-                "<CENTER>"
-                "<BR><IMG SRC=\":/icons/qtask.svg\">"
-                "<P> Version <B>%1</B><BR>"
-                "QTask is an open-source organizer based on Taskwarrior.<BR>"
-                "<P> Components: Qt-%2,%3 <a "
-                "href=\"https://smashicons.com/app/c/24px-icons/essentials_1/"
-                "list/soft_outline\">Essential Icon Pack</a><P>"
-                "<P><a "
-                "Website: "
-                "href=\"https://github.com/jubnzv/qtask\">https://github.com/"
-                "jubnzv/qtask</a><P>"
-                "<a E-mail: "
-                "href=\"mailto:jubnzv@gmail.com\">jubnzv@gmail.com</a><P>"
-                "</P>"
-                "</CENTER></body></html>")
+        QString(
+            tr("<html><style>a { color: blue; text-decoration: none; "
+               "}</style><body>"
+               "<CENTER>"
+               "<BR><IMG SRC=\":/icons/qtask.svg\">"
+               "<P> Version <B>%1</B><BR>"
+               "QTask is an open-source organizer based on Taskwarrior.<BR>"
+               "<P> Components: Qt-%2,%3 <a "
+               "href=\"https://smashicons.com/app/c/24px-icons/essentials_1/"
+               "list/soft_outline\">Essential Icon Pack</a><P>"
+               "<P><a "
+               "Website: "
+               "href=\"https://github.com/jubnzv/qtask\">https://github.com/"
+               "jubnzv/qtask</a><P>"
+               "<a E-mail: "
+               "href=\"mailto:jubnzv@gmail.com\">jubnzv@gmail.com</a><P>"
+               "</P>"
+               "</CENTER></body></html>"))
             .arg(version, QT_VERSION_STR,
                  (task_version.isNull()
                       ? ""
-                      : QString("task %1,").arg(task_version.toString())));
+                      : QString(tr("task %1,")).arg(task_version.toString())));
 
-    QVBoxLayout *main_layout = new QVBoxLayout();
-    QLabel *info_label = new QLabel(info);
+    auto *main_layout = new QVBoxLayout(this);
+    auto *info_label = new QLabel(info, this);
     info_label->setOpenExternalLinks(true);
     info_label->setTextInteractionFlags(Qt::TextBrowserInteraction);
     main_layout->addWidget(info_label);

--- a/src/aboutdialog.cpp
+++ b/src/aboutdialog.cpp
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QString>
 #include <QVBoxLayout>
+#include <qtconfiginclude.h>
 
 #include "config.hpp"
 

--- a/src/aboutdialog.hpp
+++ b/src/aboutdialog.hpp
@@ -3,12 +3,13 @@
 
 #include <QDialog>
 #include <QVariant>
+#include <QWidget>
 
-class AboutDialog : public QDialog {
+class AboutDialog final : public QDialog {
   public:
     explicit AboutDialog(const QVariant &task_version,
                          QWidget *parent = nullptr);
-    ~AboutDialog() = default;
+    ~AboutDialog() final;
 
   private:
     void initUI(const QVariant &task_version);

--- a/src/agendadialog.cpp
+++ b/src/agendadialog.cpp
@@ -14,9 +14,9 @@
 
 #include "task.hpp"
 
-AgendaDialog::AgendaDialog(const QList<Task> &tasks, QWidget *parent)
+AgendaDialog::AgendaDialog(QList<Task> tasks, QWidget *parent)
     : QDialog(parent)
-    , m_tasks(tasks)
+    , m_tasks(std::move(tasks))
 {
     initUI();
 }

--- a/src/agendadialog.hpp
+++ b/src/agendadialog.hpp
@@ -4,6 +4,7 @@
 #include <QCalendarWidget>
 #include <QDialog>
 #include <QListWidget>
+#include <QVBoxLayout>
 
 #include "task.hpp"
 
@@ -22,9 +23,12 @@ class AgendaDialog : public QDialog {
     void onUpdateTasks();
 
   private:
-    QCalendarWidget *m_calendar;
-    QListWidget *m_sched_tasks_list;
-    QListWidget *m_due_tasks_list;
+    QVBoxLayout *CreateLabeledVerticalLayout(const QString &label_text,
+                                             QWidget *widget);
+
+    QCalendarWidget *const m_calendar;
+    QListWidget *const m_sched_tasks_list;
+    QListWidget *const m_due_tasks_list;
     QList<Task> m_tasks;
 };
 

--- a/src/agendadialog.hpp
+++ b/src/agendadialog.hpp
@@ -11,8 +11,8 @@ class AgendaDialog : public QDialog {
     Q_OBJECT
 
   public:
-    AgendaDialog(const QList<Task> &, QWidget *parent = nullptr);
-    ~AgendaDialog();
+    explicit AgendaDialog(QList<Task>, QWidget *parent = nullptr);
+    ~AgendaDialog() override;
 
   private:
     void initUI();

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -4,6 +4,7 @@
 
 #include <QDebug>
 #include <QDir>
+#include <QObject>
 #include <QSettings>
 #include <QStandardPaths>
 #include <QString>

--- a/src/datetimedialog.cpp
+++ b/src/datetimedialog.cpp
@@ -3,63 +3,62 @@
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDateTimeEdit>
+#include <QDialog>
 #include <QDialogButtonBox>
+#include <QString>
 #include <QVBoxLayout>
+#include <QWidget>
+#include <qnamespace.h>
+#include <utility>
 
 DateTimeDialog::DateTimeDialog(QWidget *parent)
-    : QDialog(parent)
-    , m_datetime(QDateTime::currentDateTime())
+    : DateTimeDialog(QDateTime::currentDateTime(), parent)
 {
-    initUI();
 }
 
-DateTimeDialog::DateTimeDialog(const QDateTime &datetime, QWidget *parent)
+DateTimeDialog::DateTimeDialog(QDateTime datetime, QWidget *parent)
     : QDialog(parent)
-    , m_datetime(datetime)
-{
-    initUI();
-}
-
-DateTimeDialog::~DateTimeDialog() {}
-
-QDateTime DateTimeDialog::getDateTime() const { return m_datetime; }
-
-void DateTimeDialog::initUI()
+    , m_calendar(new QCalendarWidget(this))
+    , m_datetime_edit(new QDateTimeEdit(this))
+    , m_datetime(std::move(datetime))
 {
     setSizeGripEnabled(false);
     resize(260, 230);
+    setWindowTitle(tr("Select date"));
 
-    setWindowTitle(QCoreApplication::applicationName() + " - Select date");
+    auto *buttons = new QDialogButtonBox(this);
+    {
+        auto *vl = new QVBoxLayout(this);
+        vl->setObjectName(QString::fromUtf8("verticalLayout"));
+        vl->setContentsMargins(0, 0, 0, 0);
+        vl->addWidget(m_calendar);
+        vl->addWidget(m_datetime_edit);
+        vl->addWidget(buttons);
+    }
 
-    auto *vl = new QVBoxLayout(this);
-    vl->setObjectName(QString::fromUtf8("verticalLayout"));
-    vl->setContentsMargins(0, 0, 0, 0);
-
-    m_calendar = new QCalendarWidget(this);
     m_calendar->setObjectName(QString::fromUtf8("m_calendar"));
     m_calendar->setSelectedDate(m_datetime.date());
-    vl->addWidget(m_calendar);
     connect(m_calendar, &QCalendarWidget::selectionChanged, this, [&]() {
         m_datetime_edit->setDate(m_calendar->selectedDate());
         m_datetime = m_datetime_edit->dateTime();
     });
 
-    m_datetime_edit = new QDateTimeEdit(this);
     m_datetime_edit->setObjectName(QString::fromUtf8("m_datetime_edit"));
     m_datetime_edit->setDateTime(m_datetime);
-    vl->addWidget(m_datetime_edit);
+
     connect(m_datetime_edit, &QDateTimeEdit::dateTimeChanged, this, [&]() {
         m_datetime = m_datetime_edit->dateTime();
         m_calendar->setSelectedDate(m_datetime.date());
     });
 
-    auto *buttons = new QDialogButtonBox(this);
     buttons->setObjectName(QString::fromUtf8("buttons"));
     buttons->setOrientation(Qt::Horizontal);
     buttons->setStandardButtons(QDialogButtonBox::Cancel |
                                 QDialogButtonBox::Ok);
-    vl->addWidget(buttons);
-
     connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
 }
+
+DateTimeDialog::~DateTimeDialog() = default;
+
+const QDateTime &DateTimeDialog::getDateTime() const { return m_datetime; }

--- a/src/datetimedialog.hpp
+++ b/src/datetimedialog.hpp
@@ -10,18 +10,14 @@ class DateTimeDialog : public QDialog {
 
   public:
     DateTimeDialog(QWidget *parent = nullptr);
-    DateTimeDialog(const QDateTime &, QWidget *parent = nullptr);
-    ~DateTimeDialog();
+    DateTimeDialog(QDateTime, QWidget *parent = nullptr);
+    ~DateTimeDialog() override;
 
-    QDateTime getDateTime() const;
-
-  private:
-    void initUI();
+    const QDateTime &getDateTime() const;
 
   private:
-    QDateTimeEdit *m_datetime_edit;
-    QCalendarWidget *m_calendar;
-
+    QCalendarWidget *const m_calendar;
+    QDateTimeEdit *const m_datetime_edit;
     QDateTime m_datetime;
 };
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,5 +1,7 @@
 #include "mainwindow.hpp"
 
+#include <QAbstractItemView>
+#include <QApplication>
 #include <QCoreApplication>
 #include <QDebug>
 #include <QDesktopServices>
@@ -7,14 +9,24 @@
 #include <QEvent>
 #include <QGridLayout>
 #include <QHeaderView>
+#include <QItemSelectionModel>
+#include <QLineEdit>
+#include <QList>
 #include <QMenu>
 #include <QMenuBar>
 #include <QMessageBox>
+#include <QObject>
+#include <QStringList>
+#include <QSystemTrayIcon>
 #include <QTableView>
 #include <QToolBar>
 #include <QVariant>
 #include <QWindowStateChangeEvent>
+
 #include <qassert.h>
+#include <qnamespace.h>
+#include <qtmetamacros.h>
+#include <qtypes.h>
 
 #include "aboutdialog.hpp"
 #include "agendadialog.hpp"
@@ -24,23 +36,38 @@
 #include "recurringdialog.hpp"
 #include "settingsdialog.hpp"
 #include "tagsedit.hpp"
+#include "task.hpp"
 #include "taskdescriptiondelegate.hpp"
 #include "taskdialog.hpp"
 #include "tasksmodel.hpp"
 #include "tasksview.hpp"
 #include "taskwarrior.hpp"
 #include "taskwarriorreferencedialog.hpp"
+#include "taskwatcher.hpp"
 #include "trayicon.hpp"
 
+#include <cassert>
+#include <map>
 #include <memory>
+#include <optional>
+#include <utility>
 
 using namespace ui;
 
 MainWindow::MainWindow()
     : m_window_prev_state(Qt::WindowNoState)
     , m_is_quit(false)
+    , m_window(new QWidget(this))
+    , m_layout(new QGridLayout(m_window))
+    , m_tray_icon(new SystemTrayIcon(this))
+    , m_tasks_view(new TasksView(m_window))
+    , m_task_toolbar(new QToolBar(tr("Task Toolbar"), m_window))
+    , m_task_shell(new QLineEdit(m_window))
+    , m_task_filter(new TagsEdit(m_window))
+    , m_view_menu_actions(*menuBar()->addMenu(tr("&View")))
+    , m_toolbar_actions(*m_task_toolbar)
     , m_task_provider(std::make_unique<Taskwarrior>())
-    , m_task_watcher(nullptr)
+    , m_task_watcher(std::make_unique<TaskWatcher>(nullptr))
 {
     if (!m_task_provider->init()) {
         QMessageBox::critical(
@@ -61,7 +88,7 @@ MainWindow::MainWindow()
     initMainWindow();
     initTrayIcon();
     initFileMenu();
-    initViewMenu();
+    connectViewMenuActions();
     initToolsMenu();
     initHelpMenu();
     initShortcuts();
@@ -86,8 +113,7 @@ MainWindow::~MainWindow()
 
 bool MainWindow::initTaskWatcher()
 {
-    Q_ASSERT(!m_task_watcher);
-    m_task_watcher.reset(new TaskWatcher(this));
+    Q_ASSERT(m_task_watcher);
     if (!m_task_watcher->setup(ConfigManager::config().getTaskDataPath())) {
         m_task_watcher = nullptr;
         return false;
@@ -104,22 +130,15 @@ void MainWindow::initMainWindow()
     setWindowTitle(QCoreApplication::applicationName());
     setMinimumSize(400, 500);
 
-    m_window = new QWidget();
-
-    m_layout = new QGridLayout();
-
-    initTaskToolbar();
-
+    connectTaskToolbarActions();
     initTasksTable();
 
-    m_task_shell = new QLineEdit();
     m_task_shell->addAction(QIcon(":/icons/taskwarrior.png"),
                             QLineEdit::LeadingPosition);
     connect(m_task_shell, &QLineEdit::returnPressed, this,
             &MainWindow::onEnterTaskCommand);
     m_task_shell->setVisible(ConfigManager::config().getShowTaskShell());
 
-    m_task_filter = new TagsEdit(/* TODO: QIcon(":/icons/filter.svg")*/);
     connect(m_task_filter, &TagsEdit::tagsChanged, this,
             &MainWindow::onApplyFilter);
 
@@ -136,14 +155,13 @@ void MainWindow::initMainWindow()
 
 void MainWindow::initTasksTable()
 {
-    m_tasks_view = new TasksView(m_window);
     m_tasks_view->setShowGrid(true);
 
     m_tasks_view->verticalHeader()->setVisible(false);
     m_tasks_view->horizontalHeader()->setStretchLastSection(true);
     m_tasks_view->setSelectionBehavior(QAbstractItemView::SelectRows);
 
-    TasksModel *model = new TasksModel();
+    auto *model = new TasksModel(this);
     m_tasks_view->setModel(model);
     m_tasks_view->setItemDelegateForColumn(2 /* description */,
                                            new TaskDescriptionDelegate(this));
@@ -164,19 +182,19 @@ void MainWindow::initTasksTable()
     connect(m_tasks_view, &TasksView::selectedTaskIsActive, this,
             [&](bool is_active) {
                 if (is_active) {
-                    removeShortcutFromToolTip(m_start_action);
-                    removeShortcutFromToolTip(m_stop_action);
-                    m_stop_action->setShortcut(tr("CTRL+S"));
-                    addShortcutToToolTip(m_stop_action);
-                    m_start_action->setEnabled(false);
-                    m_stop_action->setEnabled(true);
+                    removeShortcutFromToolTip(m_toolbar_actions.m_start_action);
+                    removeShortcutFromToolTip(m_toolbar_actions.m_stop_action);
+                    m_toolbar_actions.m_stop_action->setShortcut(tr("CTRL+S"));
+                    addShortcutToToolTip(m_toolbar_actions.m_stop_action);
+                    m_toolbar_actions.m_start_action->setEnabled(false);
+                    m_toolbar_actions.m_stop_action->setEnabled(true);
                 } else {
-                    removeShortcutFromToolTip(m_stop_action);
-                    removeShortcutFromToolTip(m_start_action);
-                    m_start_action->setShortcut(tr("CTRL+S"));
-                    addShortcutToToolTip(m_start_action);
-                    m_start_action->setEnabled(true);
-                    m_stop_action->setEnabled(false);
+                    removeShortcutFromToolTip(m_toolbar_actions.m_stop_action);
+                    removeShortcutFromToolTip(m_toolbar_actions.m_start_action);
+                    m_toolbar_actions.m_start_action->setShortcut(tr("CTRL+S"));
+                    addShortcutToToolTip(m_toolbar_actions.m_start_action);
+                    m_toolbar_actions.m_start_action->setEnabled(true);
+                    m_toolbar_actions.m_stop_action->setEnabled(false);
                 }
             });
 
@@ -206,64 +224,58 @@ void MainWindow::initTrayIcon()
 
 void MainWindow::initFileMenu()
 {
-    QMenu *file_menu = menuBar()->addMenu(tr("&File"));
+    auto *file_menu = menuBar()->addMenu(tr("&File"));
     file_menu->setToolTipsVisible(true);
 
-    QAction *settings = new QAction("&Settings", this);
+    auto *settings = new QAction("&Settings", this);
     settings->setShortcut(tr("CTRL+SHIFT+P"));
     file_menu->addAction(settings);
     connect(settings, &QAction::triggered, this, &MainWindow::onOpenSettings);
 
-    QAction *quit = new QAction("&Quit", this);
+    auto *quit = new QAction("&Quit", this);
     quit->setShortcut(tr("CTRL+Q"));
     file_menu->addAction(quit);
     connect(quit, &QAction::triggered, this, &MainWindow::quitApp);
 }
 
-void MainWindow::initViewMenu()
+void MainWindow::connectViewMenuActions()
 {
-    QMenu *view_menu = menuBar()->addMenu(tr("&View"));
-    view_menu->setToolTipsVisible(true);
-
-    m_toggle_task_shell_action = new QAction("&Task shell", this);
-    m_toggle_task_shell_action->setCheckable(true);
-    m_toggle_task_shell_action->setChecked(
-        ConfigManager::config().getShowTaskShell());
-    view_menu->addAction(m_toggle_task_shell_action);
-    connect(m_toggle_task_shell_action, &QAction::triggered, this,
-            &MainWindow::onToggleTaskShell);
+    connect(m_view_menu_actions.m_toggle_task_shell_action, &QAction::triggered,
+            this, &MainWindow::onToggleTaskShell);
 }
 
 void MainWindow::initToolsMenu()
 {
-    QMenu *tools_menu = menuBar()->addMenu(tr("&Tools"));
+    auto *tools_menu = menuBar()->addMenu(tr("&Tools"));
     tools_menu->setToolTipsVisible(true);
 
-    QAction *agenda_action = new QAction("&Agenda view", this);
+    auto *agenda_action = new QAction("&Agenda view", this);
     tools_menu->addAction(agenda_action);
     agenda_action->setShortcut(tr("ALT+A"));
     connect(agenda_action, &QAction::triggered, this, [&]() {
         QList<Task> tasks = {};
-        if (!m_task_provider->getTasks(tasks))
+        if (!m_task_provider->getTasks(tasks)) {
             return;
-        auto *dlg = new AgendaDialog(tasks, this);
+        }
+        auto *dlg = new AgendaDialog(std::move(tasks), this);
         dlg->open();
         QObject::connect(dlg, &QDialog::finished, dlg, &QDialog::deleteLater);
     });
 
-    QAction *recurring_action = new QAction("&Recurring templates", this);
+    auto *recurring_action = new QAction("&Recurring templates", this);
     tools_menu->addAction(recurring_action);
     recurring_action->setShortcut(tr("ALT+R"));
     connect(recurring_action, &QAction::triggered, this, [&]() {
         QList<RecurringTask> tasks;
-        if (!m_task_provider->getRecurringTasks(tasks))
+        if (!m_task_provider->getRecurringTasks(tasks)) {
             return;
-        auto *dlg = new RecurringDialog(tasks, this);
+        }
+        auto *dlg = new RecurringDialog(std::move(tasks), this);
         dlg->open();
         QObject::connect(dlg, &QDialog::finished, dlg, &QDialog::deleteLater);
     });
 
-    QAction *history_stats_action = new QAction("&Statistics", this);
+    auto *history_stats_action = new QAction("&Statistics", this);
     history_stats_action->setEnabled(false);
     tools_menu->addAction(history_stats_action);
     connect(history_stats_action, &QAction::triggered, this,
@@ -277,8 +289,7 @@ void MainWindow::initHelpMenu()
     QMenu *help_menu = menuBar()->addMenu(tr("&Help"));
     help_menu->setToolTipsVisible(true);
 
-    QAction *reference_action =
-        new QAction("&Taskwarrior quick reference", this);
+    auto *reference_action = new QAction("&Taskwarrior quick reference", this);
     help_menu->addAction(reference_action);
     connect(reference_action, &QAction::triggered, this, [&]() {
         auto *dlg = new TaskwarriorReferenceDialog(this);
@@ -288,7 +299,7 @@ void MainWindow::initHelpMenu()
 
     help_menu->addSeparator();
 
-    QAction *about_action = new QAction("&About", this);
+    auto *about_action = new QAction("&About", this);
     help_menu->addAction(about_action);
     about_action->setShortcut(tr("F1"));
     connect(about_action, &QAction::triggered, this, [&]() {
@@ -300,8 +311,8 @@ void MainWindow::initHelpMenu()
 
 void MainWindow::initShortcuts()
 {
-    QAction *focus_task_shell = new QAction(this);
-    focus_task_shell->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_T));
+    auto *focus_task_shell = new QAction(this);
+    focus_task_shell->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_T));
     connect(focus_task_shell, &QAction::triggered, this, [&]() {
         if (m_task_shell->isVisible()) {
             m_task_shell->setFocus();
@@ -309,122 +320,69 @@ void MainWindow::initShortcuts()
     });
     this->addAction(focus_task_shell);
 
-    QAction *filter_tasks = new QAction(this);
-    filter_tasks->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_F));
+    auto *filter_tasks = new QAction(this);
+    filter_tasks->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_F));
     connect(filter_tasks, &QAction::triggered, this,
             [&]() { m_task_filter->setFocus(); });
     this->addAction(filter_tasks);
 }
 
-void MainWindow::initTaskToolbar()
+void MainWindow::connectTaskToolbarActions()
 {
-    m_task_toolbar = new QToolBar("Task toolbar");
-
-    m_add_action = new QAction(QIcon(":/icons/add.svg"), tr("Add task"));
-    connect(m_add_action, &QAction::triggered, this, [&]() {
+    connect(m_toolbar_actions.m_add_action, &QAction::triggered, this, [&]() {
         m_tasks_view->selectionModel()->clearSelection();
         onAddTask();
     });
-    m_add_action->setShortcut(tr("CTRL+N"));
-    removeShortcutFromToolTip(m_add_action);
-    addShortcutToToolTip(m_add_action);
-    m_task_toolbar->addAction(m_add_action);
 
-    m_undo_action =
-        new QAction(QIcon(":/icons/undo.png"), tr("Undo last action"));
-    connect(m_undo_action, &QAction::triggered, this, [&]() {
-        if (m_task_provider->undoTask())
+    connect(m_toolbar_actions.m_undo_action, &QAction::triggered, this, [&]() {
+        if (m_task_provider->undoTask()) {
             m_tasks_view->selectionModel()->clearSelection();
-        m_undo_action->setEnabled(m_task_provider->getActionsCounter() > 0);
+        }
+        m_toolbar_actions.m_undo_action->setEnabled(
+            m_task_provider->getActionsCounter() > 0);
     });
-    m_undo_action->setEnabled(false);
-    m_undo_action->setShortcut(tr("CTRL+Z"));
-    removeShortcutFromToolTip(m_undo_action);
-    addShortcutToToolTip(m_undo_action);
-    m_task_toolbar->addAction(m_undo_action);
 
-    m_update_action =
-        new QAction(QIcon(":/icons/refresh.png"), tr("Update tasks"));
-    connect(m_update_action, &QAction::triggered, this, [&]() {
-        m_tasks_view->selectionModel()->clearSelection();
-        updateTasks(/*force=*/true);
-    });
-    m_update_action->setShortcut(tr("CTRL+R"));
-    removeShortcutFromToolTip(m_update_action);
-    addShortcutToToolTip(m_update_action);
-    m_task_toolbar->addAction(m_update_action);
+    connect(m_toolbar_actions.m_update_action, &QAction::triggered, this,
+            [&]() {
+                m_tasks_view->selectionModel()->clearSelection();
+                updateTasks(/*force=*/true);
+            });
 
-    m_task_toolbar->addSeparator();
-
-    m_done_action = new QAction(QIcon(":/icons/done.svg"), tr("Done"));
-    connect(m_done_action, &QAction::triggered, this,
+    connect(m_toolbar_actions.m_done_action, &QAction::triggered, this,
             &MainWindow::onSetTasksDone);
-    m_done_action->setShortcut(tr("CTRL+D"));
-    removeShortcutFromToolTip(m_done_action);
-    addShortcutToToolTip(m_done_action);
-    m_task_toolbar->addAction(m_done_action);
-    m_task_toolbar->addAction(m_done_action);
-    m_done_action->setEnabled(false);
 
-    m_edit_action = new QAction(QIcon(":/icons/edit.svg"), tr("Edit"));
-    connect(m_edit_action, &QAction::triggered, this,
+    connect(m_toolbar_actions.m_edit_action, &QAction::triggered, this,
             &MainWindow::onEditTaskAction);
-    m_edit_action->setShortcut(tr("CTRL+E"));
-    removeShortcutFromToolTip(m_edit_action);
-    addShortcutToToolTip(m_edit_action);
-    m_task_toolbar->addAction(m_edit_action);
-    m_edit_action->setEnabled(false);
 
-    m_wait_action = new QAction(QIcon(":/icons/wait.svg"), tr("Wait"));
-    connect(m_wait_action, &QAction::triggered, this, [&]() {
+    connect(m_toolbar_actions.m_wait_action, &QAction::triggered, this, [&]() {
         auto *dlg =
             new DateTimeDialog(QDateTime::currentDateTime().addDays(1), this);
         dlg->open();
         QObject::connect(dlg, &QDialog::accepted, [this, dlg]() {
-            auto dt = dlg->getDateTime();
-            if (m_task_provider->waitTask(getSelectedTaskIds(), dt))
+            if (m_task_provider->waitTask(getSelectedTaskIds(),
+                                          dlg->getDateTime())) {
                 updateTasks();
+            }
         });
         QObject::connect(dlg, &QDialog::finished, dlg, &QDialog::deleteLater);
     });
-    m_wait_action->setShortcut(tr("CTRL+W"));
-    removeShortcutFromToolTip(m_wait_action);
-    addShortcutToToolTip(m_wait_action);
-    m_task_toolbar->addAction(m_wait_action);
-    m_wait_action->setEnabled(false);
 
-    m_delete_action = new QAction(QIcon(":/icons/delete.svg"), tr("Delete"));
-    connect(m_delete_action, &QAction::triggered, this,
+    connect(m_toolbar_actions.m_delete_action, &QAction::triggered, this,
             &MainWindow::onDeleteTasks);
-    m_delete_action->setShortcut(tr("Delete"));
-    removeShortcutFromToolTip(m_delete_action);
-    addShortcutToToolTip(m_delete_action);
-    m_task_toolbar->addAction(m_delete_action);
-    m_delete_action->setEnabled(false);
 
-    m_task_toolbar->addSeparator();
-
-    m_start_action = new QAction(QIcon(":/icons/start.svg"), tr("Start"));
-    connect(m_start_action, &QAction::triggered, this, [&]() {
-        auto t_opt = getSelectedTaskId();
-        if (t_opt.isNull())
-            return;
-        m_task_provider->startTask(t_opt.toString());
-        updateTasks();
+    connect(m_toolbar_actions.m_start_action, &QAction::triggered, this, [&]() {
+        if (auto t_opt = getSelectedTaskId()) {
+            m_task_provider->startTask(*t_opt);
+            updateTasks();
+        }
     });
-    m_task_toolbar->addAction(m_start_action);
-    m_start_action->setEnabled(false);
 
-    m_stop_action = new QAction(QIcon(":/icons/stop.svg"), tr("Stop"));
-    connect(m_stop_action, &QAction::triggered, this, [&]() {
-        auto t_opt = getSelectedTaskId();
-        if (t_opt.isNull())
-            return;
-        m_task_provider->stopTask(t_opt.toString());
-        updateTasks();
+    connect(m_toolbar_actions.m_stop_action, &QAction::triggered, this, [&]() {
+        if (auto t_opt = getSelectedTaskId()) {
+            m_task_provider->stopTask(*t_opt);
+            updateTasks();
+        }
     });
-    m_task_toolbar->addAction(m_stop_action);
-    m_stop_action->setEnabled(false);
 }
 
 void MainWindow::toggleMainWindow()
@@ -461,7 +419,7 @@ void MainWindow::showMainWindow()
     this->activateWindow();
 }
 
-void MainWindow::receiveNewInstanceMessage(quint32, QByteArray message)
+void MainWindow::receiveNewInstanceMessage(quint32, const QByteArray &message)
 {
     if (message == "add_task") {
         onAddTask();
@@ -483,39 +441,42 @@ void MainWindow::quitApp()
 bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 {
     auto set_task_priority = [&](Task::Priority p) {
-        auto *smodel = m_tasks_view->selectionModel();
-        if (!smodel->hasSelection())
+        const auto *smodel = m_tasks_view->selectionModel();
+        if (!smodel->hasSelection()) {
             return;
-        auto *dmodel = qobject_cast<TasksModel *>(m_tasks_view->model());
+        }
+        const auto *dmodel = qobject_cast<TasksModel *>(m_tasks_view->model());
         for (const QModelIndex idx : smodel->selectedRows()) {
             auto item = dmodel->itemData(idx);
-            if (item[0].isNull())
-                continue;
-            QString tid_str = item[0].toString();
-            m_task_provider->setPriority(tid_str, p);
+            if (!item[0].isNull()) {
+                m_task_provider->setPriority(item[0].toString(), p);
+                break;
+            }
         }
     };
 
     if (watched == m_tasks_view && event->type() == QEvent::KeyPress) {
-        if (static_cast<QKeyEvent *>(event)->key() == Qt::Key_Escape) {
+        const auto keyEvent = dynamic_cast<QKeyEvent *>(event);
+        assert(keyEvent);
+
+        switch (keyEvent->key()) {
+        case Qt::Key_Escape:
             m_tasks_view->selectionModel()->clearSelection();
             return true;
-        }
-        if (static_cast<QKeyEvent *>(event)->key() == Qt::Key_0) {
-            set_task_priority(Task::Priority::Unset);
+        default: {
+            static const std::map<int, Task::Priority> key2priority{
+                { Qt::Key_0, Task::Priority::Unset },
+                { Qt::Key_3, Task::Priority::L },
+                { Qt::Key_2, Task::Priority::M },
+                { Qt::Key_1, Task::Priority::H },
+            };
+            const auto it = key2priority.find(keyEvent->key());
+            if (it == key2priority.end()) {
+                break;
+            }
+            set_task_priority(it->second);
             return true;
         }
-        if (static_cast<QKeyEvent *>(event)->key() == Qt::Key_3) {
-            set_task_priority(Task::Priority::L);
-            return true;
-        }
-        if (static_cast<QKeyEvent *>(event)->key() == Qt::Key_2) {
-            set_task_priority(Task::Priority::M);
-            return true;
-        }
-        if (static_cast<QKeyEvent *>(event)->key() == Qt::Key_1) {
-            set_task_priority(Task::Priority::H);
-            return true;
         }
     }
 
@@ -526,8 +487,8 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 void MainWindow::changeEvent(QEvent *evt)
 {
     if (evt->type() == QEvent::WindowStateChange) {
-        QWindowStateChangeEvent *e =
-            dynamic_cast<QWindowStateChangeEvent *>(evt);
+        const auto e = dynamic_cast<QWindowStateChangeEvent *>(evt);
+        assert(e);
         m_window_prev_state = e->oldState();
     }
 
@@ -546,38 +507,42 @@ void MainWindow::closeEvent(QCloseEvent *event)
     }
 }
 
-QVariant MainWindow::getSelectedTaskId()
+std::optional<QString> MainWindow::getSelectedTaskId() const
 {
     Q_ASSERT(m_tasks_view);
 
     auto *smodel = m_tasks_view->selectionModel();
-    if (smodel->selectedRows().size() != 1)
+    if (smodel->selectedRows().size() != 1) {
         return {};
+    }
 
     auto *dmodel = qobject_cast<TasksModel *>(m_tasks_view->model());
     for (const QModelIndex idx : smodel->selectedRows()) {
         auto item = dmodel->itemData(idx);
-        if (item[0].isNull())
+        if (item[0].isNull()) {
             continue;
+        }
         return item[0].toString();
     }
 
     return {};
 }
 
-QStringList MainWindow::getSelectedTaskIds()
+QStringList MainWindow::getSelectedTaskIds() const
 {
     auto *smodel = m_tasks_view->selectionModel();
-    if (!smodel->hasSelection())
+    if (!smodel->hasSelection()) {
         return {};
+    }
 
     QStringList ids;
 
     auto *dmodel = qobject_cast<TasksModel *>(m_tasks_view->model());
     for (const QModelIndex idx : smodel->selectedRows()) {
         auto item = dmodel->itemData(idx);
-        if (item[0].isNull())
+        if (item[0].isNull()) {
             continue;
+        }
         ids.push_back(item[0].toString());
     }
 
@@ -586,14 +551,15 @@ QStringList MainWindow::getSelectedTaskIds()
 
 void MainWindow::pushFilterTag(const QString &value)
 {
-    if (!m_task_filter->isVisible())
+    if (!m_task_filter->isVisible()) {
         return;
+    }
     m_task_filter->pushTag(value);
 }
 
 void MainWindow::onToggleTaskShell()
 {
-    if (m_toggle_task_shell_action->isChecked()) {
+    if (m_view_menu_actions.m_toggle_task_shell_action->isChecked()) {
         m_task_shell->setVisible(true);
         ConfigManager::config().setShowTaskShell(true);
     } else {
@@ -626,10 +592,11 @@ void MainWindow::onAddTask()
                      &AddTaskDialog::acceptContinue);
     QObject::connect(dlg, &QDialog::accepted, [this, dlg]() {
         auto t = dlg->getTask();
-        if (m_task_provider->addTask(t))
+        if (m_task_provider->addTask(t)) {
             updateTasks();
+        }
     });
-    QObject::connect(dlg, &QDialog::rejected, [this, dlg]() { updateTasks(); });
+    QObject::connect(dlg, &QDialog::rejected, [this]() { updateTasks(); });
     QObject::connect(dlg, &AddTaskDialog::createTaskAndContinue, [this, dlg]() {
         auto t = dlg->getTask();
         if (m_task_provider->addTask(t)) {
@@ -644,26 +611,29 @@ void MainWindow::onAddTask()
 
 void MainWindow::onDeleteTasks()
 {
-    auto *smodel = m_tasks_view->selectionModel();
-    QString q;
-    if (smodel->selectedRows().size() == 1)
-        q = tr("Delete task?");
-    else
-        q = tr("Delete %1 tasks?").arg(smodel->selectedRows().size());
-    QMessageBox::StandardButton reply;
-    reply = QMessageBox::question(this, tr("Conifrm action"), q,
-                                  QMessageBox::Yes | QMessageBox::No);
-    if (reply == QMessageBox::Yes) {
-        m_task_provider->deleteTask(getSelectedTaskIds());
-        smodel->clearSelection();
+    const auto selectedTasks = getSelectedTaskIds();
+    const auto selectedCount = selectedTasks.size();
+    if (selectedCount == 0) {
+        return;
+    }
+    const auto question_to_show =
+        (selectedCount == 1) ? tr("Delete task?")
+                             : tr("Delete %1 tasks?").arg(selectedCount);
+
+    if (QMessageBox::question(this, tr("Conifrm action"), question_to_show,
+                              QMessageBox::Yes | QMessageBox::No) ==
+        QMessageBox::Yes) {
+        m_tasks_view->selectionModel()->clearSelection();
+        m_task_provider->deleteTask(selectedTasks);
         updateTasks();
     }
 }
 
 void MainWindow::onSetTasksDone()
 {
-    if (!m_tasks_view->selectionModel()->hasSelection())
+    if (!m_tasks_view->selectionModel()->hasSelection()) {
         return;
+    }
     m_task_provider->setTaskDone(getSelectedTaskIds());
     m_tasks_view->selectionModel()->clearSelection();
     updateTasks();
@@ -671,8 +641,9 @@ void MainWindow::onSetTasksDone()
 
 void MainWindow::onApplyFilter()
 {
-    if (!m_task_provider->applyFilter(m_task_filter->getTags()))
+    if (!m_task_provider->applyFilter(m_task_filter->getTags())) {
         m_task_filter->popTag();
+    }
     // if (!m_task_provider->applyFilter(m_task_filter->getTags()))
     //     m_task_filter->clearTags();
     updateTasks(/*force=*/true);
@@ -681,8 +652,9 @@ void MainWindow::onApplyFilter()
 void MainWindow::onEnterTaskCommand()
 {
     auto cmd = m_task_shell->text();
-    if (cmd.isEmpty())
+    if (cmd.isEmpty()) {
         return;
+    }
     auto rc = m_task_provider->directCmd(cmd);
     if (rc == 0) {
         updateTasks();
@@ -690,11 +662,10 @@ void MainWindow::onEnterTaskCommand()
     m_task_shell->setText("");
 }
 
-void MainWindow::showEditTaskDialog(const QModelIndex &idx)
+void MainWindow::showEditTaskDialog([[maybe_unused]] const QModelIndex &idx)
 {
     const auto *model = m_tasks_view->selectionModel();
-
-    QString id_str = model->selectedRows()[0].data().toString();
+    const auto id_str = model->selectedRows()[0].data().toString();
     if (id_str.isEmpty()) {
         updateTasks();
         return;
@@ -721,18 +692,22 @@ void MainWindow::showEditTaskDialog(const QModelIndex &idx)
         auto t = dlg->getTask();
         auto new_tags = t.tags;
         t.removed_tags = QStringList();
-        for (auto const &st : saved_tags)
-            if (!new_tags.contains(st))
+        for (auto const &st : saved_tags) {
+            if (!new_tags.contains(st)) {
                 t.removed_tags.push_back(st);
+            }
+        }
         t.uuid = id_str;
-        if (!m_task_provider->editTask(t))
+        if (!m_task_provider->editTask(t)) {
             return;
+        }
         if (saved_pri != t.priority &&
-            !m_task_provider->setPriority(t.uuid, t.priority))
+            !m_task_provider->setPriority(t.uuid, t.priority)) {
             return;
+        }
         updateTasks();
     });
-    QObject::connect(dlg, &QDialog::rejected, [this, dlg]() { updateTasks(); });
+    QObject::connect(dlg, &QDialog::rejected, [this]() { updateTasks(); });
     QObject::connect(dlg, &QDialog::finished, dlg, &QDialog::deleteLater);
 }
 
@@ -749,8 +724,9 @@ void MainWindow::updateTasks(bool force)
 
     // The commands from m_task_provider will modify the taskwarrior
     // database files. This will trigger TaskWatcher to emit update event.
-    if (!force && m_task_watcher && m_task_watcher->isActive())
+    if (!force && m_task_watcher && m_task_watcher->isActive()) {
         return;
+    }
 
     QList<Task> tasks = {};
     m_task_provider->getTasks(tasks);
@@ -764,27 +740,86 @@ void MainWindow::updateTasks(bool force)
 void MainWindow::updateTaskToolbar()
 {
     const auto *model = m_tasks_view->selectionModel();
-    const int num_selected = model->selectedRows().size();
+    const auto num_selected = model->selectedRows().size();
 
-    m_undo_action->setEnabled(m_task_provider->getActionsCounter() > 0);
+    m_toolbar_actions.m_undo_action->setEnabled(
+        m_task_provider->getActionsCounter() > 0);
 
-    if (num_selected == 0) {
-        m_done_action->setEnabled(false);
-        m_edit_action->setEnabled(false);
-        m_wait_action->setEnabled(false);
-        m_delete_action->setEnabled(false);
-        m_start_action->setEnabled(false);
-        m_stop_action->setEnabled(false);
-        removeShortcutFromToolTip(m_stop_action);
-        removeShortcutFromToolTip(m_start_action);
+    if (num_selected == 0u) {
+        m_toolbar_actions.m_done_action->setEnabled(false);
+        m_toolbar_actions.m_edit_action->setEnabled(false);
+        m_toolbar_actions.m_wait_action->setEnabled(false);
+        m_toolbar_actions.m_delete_action->setEnabled(false);
+        m_toolbar_actions.m_start_action->setEnabled(false);
+        m_toolbar_actions.m_stop_action->setEnabled(false);
+        removeShortcutFromToolTip(m_toolbar_actions.m_stop_action);
+        removeShortcutFromToolTip(m_toolbar_actions.m_start_action);
     } else {
-        m_done_action->setEnabled(true);
+        m_toolbar_actions.m_done_action->setEnabled(true);
         if (num_selected == 1) {
-            m_edit_action->setEnabled(true);
+            m_toolbar_actions.m_edit_action->setEnabled(true);
         } else {
-            m_edit_action->setEnabled(false);
+            m_toolbar_actions.m_edit_action->setEnabled(false);
         }
-        m_wait_action->setEnabled(true);
-        m_delete_action->setEnabled(true);
+        m_toolbar_actions.m_wait_action->setEnabled(true);
+        m_toolbar_actions.m_delete_action->setEnabled(true);
     }
+}
+
+MainWindow::TToolbarActionsDefined::TToolbarActionsDefined(QToolBar &parent)
+{
+    const auto allocate = [&parent](const QString &path, const QString &text) {
+        auto action = new QAction(QIcon(path), text, &parent);
+        action->setEnabled(true);
+        removeShortcutFromToolTip(action);
+        addShortcutToToolTip(action);
+        parent.addAction(action);
+        return action;
+    };
+
+    m_add_action = allocate(":/icons/add.svg", tr("Add task"));
+    m_add_action->setShortcut(tr("CTRL+N"));
+
+    m_undo_action = allocate(":/icons/undo.png", tr("Undo last action"));
+    m_undo_action->setEnabled(false);
+    m_undo_action->setShortcut(tr("CTRL+Z"));
+
+    m_update_action = allocate(":/icons/refresh.png", tr("Update tasks"));
+    m_update_action->setShortcut(tr("CTRL+R"));
+
+    parent.addSeparator();
+
+    m_done_action = allocate(":/icons/done.svg", tr("Done"));
+    m_done_action->setShortcut(tr("CTRL+D"));
+    m_done_action->setEnabled(false);
+
+    m_edit_action = allocate(":/icons/edit.svg", tr("Edit"));
+    m_edit_action->setShortcut(tr("CTRL+E"));
+    m_edit_action->setEnabled(false);
+
+    m_wait_action = allocate(":/icons/wait.svg", tr("Wait"));
+    m_wait_action->setShortcut(tr("CTRL+W"));
+    m_wait_action->setEnabled(false);
+
+    m_delete_action = allocate(":/icons/delete.svg", tr("Delete"));
+    m_delete_action->setShortcut(tr("Delete"));
+    m_delete_action->setEnabled(false);
+
+    parent.addSeparator();
+
+    m_start_action = allocate(":/icons/start.svg", tr("Start"));
+    m_start_action->setEnabled(false);
+
+    m_stop_action = allocate(":/icons/stop.svg", tr("Stop"));
+    m_stop_action->setEnabled(false);
+}
+
+MainWindow::TViewMenuActions::TViewMenuActions(QMenu &parent)
+{
+    parent.setToolTipsVisible(true);
+    m_toggle_task_shell_action = new QAction(tr("&Task shell"), &parent);
+    m_toggle_task_shell_action->setCheckable(true);
+    m_toggle_task_shell_action->setChecked(
+        ConfigManager::config().getShowTaskShell());
+    parent.addAction(m_toggle_task_shell_action);
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -597,12 +597,14 @@ void MainWindow::onAddTask()
         }
     }
 
-    auto *dlg = new AddTaskDialog(default_project, this);
+    auto dlg =
+        QPointer<AddTaskDialog>(new AddTaskDialog(default_project, this));
     dlg->open();
 
     QObject::connect(this, &MainWindow::acceptContinueCreatingTasks, dlg,
                      &AddTaskDialog::acceptContinue);
     QObject::connect(dlg, &QDialog::accepted, [this, dlg]() {
+        Q_ASSERT(dlg);
         auto t = dlg->getTask();
         if (m_task_provider->addTask(t)) {
             updateTasks();
@@ -610,6 +612,7 @@ void MainWindow::onAddTask()
     });
     QObject::connect(dlg, &QDialog::rejected, [this]() { updateTasks(); });
     QObject::connect(dlg, &AddTaskDialog::createTaskAndContinue, [this, dlg]() {
+        Q_ASSERT(dlg);
         auto t = dlg->getTask();
         if (m_task_provider->addTask(t)) {
             updateTasks();
@@ -689,7 +692,7 @@ void MainWindow::showEditTaskDialog([[maybe_unused]] const QModelIndex &idx)
         return;
     }
 
-    auto *dlg = new EditTaskDialog(task, this);
+    auto dlg = QPointer<EditTaskDialog>(new EditTaskDialog(task, this));
     dlg->open();
 
     QObject::connect(dlg, &EditTaskDialog::deleteTask, this,
@@ -699,11 +702,12 @@ void MainWindow::showEditTaskDialog([[maybe_unused]] const QModelIndex &idx)
                          updateTasks();
                      });
     QObject::connect(dlg, &QDialog::accepted, [this, dlg, id_str, task]() {
+        Q_ASSERT(dlg);
         auto saved_tags = task.tags;
         auto saved_pri = task.priority;
         auto t = dlg->getTask();
         auto new_tags = t.tags;
-        t.removed_tags = QStringList();
+        t.removed_tags.clear();
         for (auto const &st : saved_tags) {
             if (!new_tags.contains(st)) {
                 t.removed_tags.push_back(st);

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -184,14 +184,16 @@ void MainWindow::initTasksTable()
                 if (is_active) {
                     removeShortcutFromToolTip(m_toolbar_actions.m_start_action);
                     removeShortcutFromToolTip(m_toolbar_actions.m_stop_action);
-                    m_toolbar_actions.m_stop_action->setShortcut(tr("CTRL+S"));
+                    m_toolbar_actions.m_stop_action->setShortcut(
+                        QKeySequence("CTRL+S"));
                     addShortcutToToolTip(m_toolbar_actions.m_stop_action);
                     m_toolbar_actions.m_start_action->setEnabled(false);
                     m_toolbar_actions.m_stop_action->setEnabled(true);
                 } else {
                     removeShortcutFromToolTip(m_toolbar_actions.m_stop_action);
                     removeShortcutFromToolTip(m_toolbar_actions.m_start_action);
-                    m_toolbar_actions.m_start_action->setShortcut(tr("CTRL+S"));
+                    m_toolbar_actions.m_start_action->setShortcut(
+                        QKeySequence("CTRL+S"));
                     addShortcutToToolTip(m_toolbar_actions.m_start_action);
                     m_toolbar_actions.m_start_action->setEnabled(true);
                     m_toolbar_actions.m_stop_action->setEnabled(false);
@@ -228,12 +230,12 @@ void MainWindow::initFileMenu()
     file_menu->setToolTipsVisible(true);
 
     auto *settings = new QAction("&Settings", this);
-    settings->setShortcut(tr("CTRL+SHIFT+P"));
+    settings->setShortcut(QKeySequence("CTRL+SHIFT+P"));
     file_menu->addAction(settings);
     connect(settings, &QAction::triggered, this, &MainWindow::onOpenSettings);
 
     auto *quit = new QAction("&Quit", this);
-    quit->setShortcut(tr("CTRL+Q"));
+    quit->setShortcut(QKeySequence("CTRL+Q"));
     file_menu->addAction(quit);
     connect(quit, &QAction::triggered, this, &MainWindow::quitApp);
 }
@@ -778,31 +780,31 @@ MainWindow::TToolbarActionsDefined::TToolbarActionsDefined(QToolBar &parent)
     };
 
     m_add_action = allocate(":/icons/add.svg", tr("Add task"));
-    m_add_action->setShortcut(tr("CTRL+N"));
+    m_add_action->setShortcut(QKeySequence("CTRL+N"));
 
     m_undo_action = allocate(":/icons/undo.png", tr("Undo last action"));
     m_undo_action->setEnabled(false);
-    m_undo_action->setShortcut(tr("CTRL+Z"));
+    m_undo_action->setShortcut(QKeySequence("CTRL+Z"));
 
     m_update_action = allocate(":/icons/refresh.png", tr("Update tasks"));
-    m_update_action->setShortcut(tr("CTRL+R"));
+    m_update_action->setShortcut(QKeySequence("CTRL+R"));
 
     parent.addSeparator();
 
     m_done_action = allocate(":/icons/done.svg", tr("Done"));
-    m_done_action->setShortcut(tr("CTRL+D"));
+    m_done_action->setShortcut(QKeySequence("CTRL+D"));
     m_done_action->setEnabled(false);
 
     m_edit_action = allocate(":/icons/edit.svg", tr("Edit"));
-    m_edit_action->setShortcut(tr("CTRL+E"));
+    m_edit_action->setShortcut(QKeySequence("CTRL+E"));
     m_edit_action->setEnabled(false);
 
     m_wait_action = allocate(":/icons/wait.svg", tr("Wait"));
-    m_wait_action->setShortcut(tr("CTRL+W"));
+    m_wait_action->setShortcut(QKeySequence("CTRL+W"));
     m_wait_action->setEnabled(false);
 
     m_delete_action = allocate(":/icons/delete.svg", tr("Delete"));
-    m_delete_action->setShortcut(tr("Delete"));
+    m_delete_action->setShortcut(QKeySequence::Delete);
     m_delete_action->setEnabled(false);
 
     parent.addSeparator();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -54,6 +54,16 @@
 
 using namespace ui;
 
+namespace
+{
+const auto kStartStopShortcut = QKeySequence("CTRL+S");
+const auto kSettingsButtonShortcut = QKeySequence("CTRL+SHIFT+S");
+const auto kActivateTaskShellShortcut = QKeySequence("CTRL+T");
+const auto kDoneShortcut = QKeySequence("CTRL+D");
+const auto kEditShortcut = QKeySequence("CTRL+E");
+const auto kWaitShortcut = QKeySequence("CTRL+W");
+} // namespace
+
 MainWindow::MainWindow()
     : m_window_prev_state(Qt::WindowNoState)
     , m_is_quit(false)
@@ -185,7 +195,7 @@ void MainWindow::initTasksTable()
                     removeShortcutFromToolTip(m_toolbar_actions.m_start_action);
                     removeShortcutFromToolTip(m_toolbar_actions.m_stop_action);
                     m_toolbar_actions.m_stop_action->setShortcut(
-                        QKeySequence("CTRL+S"));
+                        kStartStopShortcut);
                     addShortcutToToolTip(m_toolbar_actions.m_stop_action);
                     m_toolbar_actions.m_start_action->setEnabled(false);
                     m_toolbar_actions.m_stop_action->setEnabled(true);
@@ -193,7 +203,7 @@ void MainWindow::initTasksTable()
                     removeShortcutFromToolTip(m_toolbar_actions.m_stop_action);
                     removeShortcutFromToolTip(m_toolbar_actions.m_start_action);
                     m_toolbar_actions.m_start_action->setShortcut(
-                        QKeySequence("CTRL+S"));
+                        kStartStopShortcut);
                     addShortcutToToolTip(m_toolbar_actions.m_start_action);
                     m_toolbar_actions.m_start_action->setEnabled(true);
                     m_toolbar_actions.m_stop_action->setEnabled(false);
@@ -230,12 +240,12 @@ void MainWindow::initFileMenu()
     file_menu->setToolTipsVisible(true);
 
     auto *settings = new QAction("&Settings", this);
-    settings->setShortcut(QKeySequence("CTRL+SHIFT+P"));
+    settings->setShortcut(kSettingsButtonShortcut);
     file_menu->addAction(settings);
     connect(settings, &QAction::triggered, this, &MainWindow::onOpenSettings);
 
     auto *quit = new QAction("&Quit", this);
-    quit->setShortcut(QKeySequence("CTRL+Q"));
+    quit->setShortcut(QKeySequence::Quit);
     file_menu->addAction(quit);
     connect(quit, &QAction::triggered, this, &MainWindow::quitApp);
 }
@@ -314,19 +324,19 @@ void MainWindow::initHelpMenu()
 void MainWindow::initShortcuts()
 {
     auto *focus_task_shell = new QAction(this);
-    focus_task_shell->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_T));
+    focus_task_shell->setShortcut(kActivateTaskShellShortcut);
     connect(focus_task_shell, &QAction::triggered, this, [&]() {
         if (m_task_shell->isVisible()) {
             m_task_shell->setFocus();
         }
     });
-    this->addAction(focus_task_shell);
+    addAction(focus_task_shell);
 
     auto *filter_tasks = new QAction(this);
-    filter_tasks->setShortcut(QKeySequence(Qt::CTRL | Qt::Key_F));
+    filter_tasks->setShortcut(QKeySequence::Find);
     connect(filter_tasks, &QAction::triggered, this,
             [&]() { m_task_filter->setFocus(); });
-    this->addAction(filter_tasks);
+    addAction(filter_tasks);
 }
 
 void MainWindow::connectTaskToolbarActions()
@@ -770,49 +780,49 @@ void MainWindow::updateTaskToolbar()
 
 MainWindow::TToolbarActionsDefined::TToolbarActionsDefined(QToolBar &parent)
 {
-    const auto allocate = [&parent](const QString &path, const QString &text) {
+    const auto allocate = [&parent](const QString &path, const QString &text,
+                                    const QKeySequence &short_cut) {
         auto action = new QAction(QIcon(path), text, &parent);
         action->setEnabled(true);
+        action->setShortcut(short_cut);
         removeShortcutFromToolTip(action);
         addShortcutToToolTip(action);
         parent.addAction(action);
         return action;
     };
 
-    m_add_action = allocate(":/icons/add.svg", tr("Add task"));
-    m_add_action->setShortcut(QKeySequence("CTRL+N"));
-
-    m_undo_action = allocate(":/icons/undo.png", tr("Undo last action"));
+    m_add_action =
+        allocate(":/icons/add.svg", tr("Add task"), QKeySequence::New);
+    m_undo_action = allocate(":/icons/undo.png", tr("Undo last action"),
+                             QKeySequence::Undo);
     m_undo_action->setEnabled(false);
-    m_undo_action->setShortcut(QKeySequence("CTRL+Z"));
 
-    m_update_action = allocate(":/icons/refresh.png", tr("Update tasks"));
-    m_update_action->setShortcut(QKeySequence("CTRL+R"));
+    m_update_action = allocate(":/icons/refresh.png", tr("Update tasks"),
+                               QKeySequence::Refresh);
 
     parent.addSeparator();
 
-    m_done_action = allocate(":/icons/done.svg", tr("Done"));
-    m_done_action->setShortcut(QKeySequence("CTRL+D"));
+    m_done_action = allocate(":/icons/done.svg", tr("Done"), kDoneShortcut);
     m_done_action->setEnabled(false);
 
-    m_edit_action = allocate(":/icons/edit.svg", tr("Edit"));
-    m_edit_action->setShortcut(QKeySequence("CTRL+E"));
+    m_edit_action = allocate(":/icons/edit.svg", tr("Edit"), kEditShortcut);
     m_edit_action->setEnabled(false);
 
-    m_wait_action = allocate(":/icons/wait.svg", tr("Wait"));
-    m_wait_action->setShortcut(QKeySequence("CTRL+W"));
+    m_wait_action = allocate(":/icons/wait.svg", tr("Wait"), kWaitShortcut);
     m_wait_action->setEnabled(false);
 
-    m_delete_action = allocate(":/icons/delete.svg", tr("Delete"));
-    m_delete_action->setShortcut(QKeySequence::Delete);
+    m_delete_action =
+        allocate(":/icons/delete.svg", tr("Delete"), QKeySequence::Delete);
     m_delete_action->setEnabled(false);
 
     parent.addSeparator();
 
-    m_start_action = allocate(":/icons/start.svg", tr("Start"));
+    m_start_action =
+        allocate(":/icons/start.svg", tr("Start"), QKeySequence::UnknownKey);
     m_start_action->setEnabled(false);
 
-    m_stop_action = allocate(":/icons/stop.svg", tr("Stop"));
+    m_stop_action =
+        allocate(":/icons/stop.svg", tr("Stop"), QKeySequence::UnknownKey);
     m_stop_action->setEnabled(false);
 }
 

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -215,8 +215,6 @@ void MainWindow::initTasksTable()
 
 void MainWindow::initTrayIcon()
 {
-    m_tray_icon = new SystemTrayIcon(this);
-
     connect(m_tray_icon, &SystemTrayIcon::muteNotificationsRequested, this,
             &MainWindow::onMuteNotifications);
     connect(m_tray_icon, &SystemTrayIcon::addTaskRequested, this,

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -2,19 +2,23 @@
 #define MAINWINDOW_HPP
 
 #include <memory>
+#include <optional>
 
 #include <QCloseEvent>
 #include <QEvent>
 #include <QGridLayout>
 #include <QLineEdit>
 #include <QMainWindow>
+#include <QObject>
 #include <QPointer>
+#include <QStringList>
 #include <QSystemTrayIcon>
 #include <QTableView>
 #include <QVariant>
+#include <qnamespace.h>
+#include <qtypes.h>
 
 #include "tagsedit.hpp"
-#include "task.hpp"
 #include "tasksview.hpp"
 #include "taskwarrior.hpp"
 #include "taskwatcher.hpp"
@@ -27,7 +31,11 @@ class MainWindow : public QMainWindow {
 
   public:
     MainWindow();
-    ~MainWindow();
+    ~MainWindow() override;
+    MainWindow(const MainWindow &) = delete;
+    MainWindow &operator=(const MainWindow &) = delete;
+    MainWindow(MainWindow &&) = delete;
+    MainWindow &operator=(MainWindow &&) = delete;
 
   private:
     bool initTaskWatcher();
@@ -36,11 +44,11 @@ class MainWindow : public QMainWindow {
     void initTasksTable();
     void initTrayIcon();
     void initFileMenu();
-    void initViewMenu();
+    void connectViewMenuActions();
     void initToolsMenu();
     void initHelpMenu();
     void initShortcuts();
-    void initTaskToolbar();
+    void connectTaskToolbarActions();
     void toggleMainWindow();
     void onOpenSettings();
     void quitApp();
@@ -49,8 +57,8 @@ class MainWindow : public QMainWindow {
     void changeEvent(QEvent *) override;
     void closeEvent(QCloseEvent *event) override;
 
-    QVariant getSelectedTaskId();
-    QStringList getSelectedTaskIds();
+    [[nodiscard]] std::optional<QString> getSelectedTaskId() const;
+    [[nodiscard]] QStringList getSelectedTaskIds() const;
 
   public slots:
     /// Add entry to tags filter
@@ -60,7 +68,8 @@ class MainWindow : public QMainWindow {
     void showMainWindow();
 
     /// Receive a message from a secondary QTask instance
-    void receiveNewInstanceMessage(quint32 instanceId, QByteArray message);
+    void receiveNewInstanceMessage(quint32 instanceId,
+                                   const QByteArray &message);
 
   private slots:
     void onToggleTaskShell();
@@ -87,8 +96,6 @@ class MainWindow : public QMainWindow {
     /// Flag to decide: close application or hide it to tray
     bool m_is_quit;
 
-    QAction *m_toggle_task_shell_action;
-
     QWidget *m_window;
     QGridLayout *m_layout;
     SystemTrayIcon *m_tray_icon;
@@ -97,16 +104,28 @@ class MainWindow : public QMainWindow {
     QLineEdit *m_task_shell;
     TagsEdit *m_task_filter;
 
-    // Toolbar actions
-    QAction *m_add_action;
-    QAction *m_undo_action;
-    QAction *m_update_action;
-    QAction *m_done_action;
-    QAction *m_edit_action;
-    QAction *m_wait_action;
-    QAction *m_delete_action;
-    QAction *m_start_action;
-    QAction *m_stop_action;
+    // Allocates and holds pointers to view menu actions.
+    // Parent is set to this menu.
+    struct TViewMenuActions {
+        QPointer<QAction> m_toggle_task_shell_action;
+        explicit TViewMenuActions(QMenu &parent);
+    } m_view_menu_actions;
+
+    // Allocates and holds pointers for toolbar actions.
+    // Parent is set to toolbar.
+    // Note, any action can be addded to the toolbar later too.
+    struct TToolbarActionsDefined {
+        QPointer<QAction> m_add_action;
+        QPointer<QAction> m_undo_action;
+        QPointer<QAction> m_update_action;
+        QPointer<QAction> m_done_action;
+        QPointer<QAction> m_edit_action;
+        QPointer<QAction> m_wait_action;
+        QPointer<QAction> m_delete_action;
+        QPointer<QAction> m_start_action;
+        QPointer<QAction> m_stop_action;
+        explicit TToolbarActionsDefined(QToolBar &parent);
+    } m_toolbar_actions;
 
     std::unique_ptr<Taskwarrior> m_task_provider;
     std::unique_ptr<TaskWatcher> m_task_watcher;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -16,6 +16,7 @@
 #include <QTableView>
 #include <QVariant>
 #include <qnamespace.h>
+#include <qtmetamacros.h>
 #include <qtypes.h>
 
 #include "tagsedit.hpp"
@@ -96,20 +97,20 @@ class MainWindow : public QMainWindow {
     /// Flag to decide: close application or hide it to tray
     bool m_is_quit;
 
-    QWidget *m_window;
-    QGridLayout *m_layout;
-    SystemTrayIcon *m_tray_icon;
-    TasksView *m_tasks_view;
-    QToolBar *m_task_toolbar;
-    QLineEdit *m_task_shell;
-    TagsEdit *m_task_filter;
+    QWidget *const m_window;
+    QGridLayout *const m_layout;
+    SystemTrayIcon *const m_tray_icon;
+    TasksView *const m_tasks_view;
+    QToolBar *const m_task_toolbar;
+    QLineEdit *const m_task_shell;
+    TagsEdit *const m_task_filter;
 
     // Allocates and holds pointers to view menu actions.
     // Parent is set to this menu.
     struct TViewMenuActions {
         QPointer<QAction> m_toggle_task_shell_action;
         explicit TViewMenuActions(QMenu &parent);
-    } m_view_menu_actions;
+    } const m_view_menu_actions;
 
     // Allocates and holds pointers for toolbar actions.
     // Parent is set to toolbar.
@@ -125,7 +126,7 @@ class MainWindow : public QMainWindow {
         QPointer<QAction> m_start_action;
         QPointer<QAction> m_stop_action;
         explicit TToolbarActionsDefined(QToolBar &parent);
-    } m_toolbar_actions;
+    } const m_toolbar_actions;
 
     std::unique_ptr<Taskwarrior> m_task_provider;
     std::unique_ptr<TaskWatcher> m_task_watcher;

--- a/src/optionaldatetimeedit.cpp
+++ b/src/optionaldatetimeedit.cpp
@@ -4,26 +4,37 @@
 #include <QCheckBox>
 #include <QDateTimeEdit>
 #include <QHBoxLayout>
+#include <QString>
 #include <QVariant>
 #include <QWidget>
 
 OptionalDateTimeEdit::OptionalDateTimeEdit(const QString &label,
                                            const QDateTime &dt, QWidget *parent)
     : QWidget(parent)
+    , m_datetime_edit(new QDateTimeEdit())
+    , m_enabled(new QCheckBox(label, this))
 {
-    initUI(label);
+    {
+        auto layout = new QHBoxLayout(this);
+        connect(m_enabled, &QCheckBox::stateChanged, this,
+                [&]() { m_datetime_edit->setEnabled(m_enabled->isChecked()); });
+        layout->addWidget(m_enabled);
+
+        m_datetime_edit->setCalendarPopup(true);
+        layout->addWidget(m_datetime_edit);
+        setLayout(layout);
+    }
     setDateTime(dt);
+    setChecked(true);
 }
 
 OptionalDateTimeEdit::OptionalDateTimeEdit(const QString &label,
                                            QWidget *parent)
-    : QWidget(parent)
+    : OptionalDateTimeEdit(label, startOfDay(QDate{ 1970, 1, 1 }), parent)
 {
-    initUI(label);
-    setDateTime(startOfDay(QDate{ 1970, 1, 1 }));
 }
 
-OptionalDateTimeEdit::~OptionalDateTimeEdit() {}
+OptionalDateTimeEdit::~OptionalDateTimeEdit() = default;
 
 QVariant OptionalDateTimeEdit::getDateTime() const
 {
@@ -59,20 +70,4 @@ void OptionalDateTimeEdit::setMinimumDateTime(const QDateTime &dt)
 void OptionalDateTimeEdit::setMaximumDateTime(const QDateTime &dt)
 {
     m_datetime_edit->setMaximumDateTime(dt);
-}
-
-void OptionalDateTimeEdit::initUI(const QString &label)
-{
-    auto layout = new QHBoxLayout(this);
-
-    m_enabled = new QCheckBox(label);
-    connect(m_enabled, &QCheckBox::stateChanged, this,
-            [&]() { m_datetime_edit->setEnabled(m_enabled->isChecked()); });
-    layout->addWidget(m_enabled);
-
-    m_datetime_edit = new QDateTimeEdit();
-    m_datetime_edit->setCalendarPopup(true);
-    layout->addWidget(m_datetime_edit);
-
-    setChecked(true);
 }

--- a/src/optionaldatetimeedit.hpp
+++ b/src/optionaldatetimeedit.hpp
@@ -2,7 +2,10 @@
 #define OPTIONALDATETIMEEDIT_HPP
 
 #include <QCheckBox>
+#include <QDateTime>
 #include <QDateTimeEdit>
+#include <QObject>
+#include <QString>
 #include <QVariant>
 #include <QWidget>
 
@@ -13,7 +16,7 @@ class OptionalDateTimeEdit : public QWidget {
     OptionalDateTimeEdit(const QString &label, const QDateTime &date,
                          QWidget *parent = nullptr);
     OptionalDateTimeEdit(const QString &label, QWidget *parent = nullptr);
-    ~OptionalDateTimeEdit();
+    ~OptionalDateTimeEdit() override;
 
     QVariant getDateTime() const;
     void setDateTime(const QDateTime &dt);
@@ -24,11 +27,8 @@ class OptionalDateTimeEdit : public QWidget {
     void setMaximumDateTime(const QDateTime &);
 
   private:
-    void initUI(const QString &label);
-
-  private:
-    QDateTimeEdit *m_datetime_edit;
-    QCheckBox *m_enabled;
+    QDateTimeEdit *const m_datetime_edit;
+    QCheckBox *const m_enabled;
 };
 
 #endif // OPTIONALDATETIMEEDIT_HPP

--- a/src/qtutil.cpp
+++ b/src/qtutil.cpp
@@ -7,68 +7,37 @@
 #include <QDateTime>
 #include <QPalette>
 #include <QString>
+#include <QStyle>
 #include <QTimeZone>
+#include <qnamespace.h>
+#include <qtconfigmacros.h>
+#include <qtversionchecks.h>
 
+namespace
+{
 // Guesses a descriptive text from a text suited for a menu entry.
 // This is equivalent to QActions internal qt_strippedText().
-static QString strippedActionText(QString s)
+QString strippedActionText(QString s)
 {
     s.remove(QString::fromLatin1("..."));
     for (int i = 0; i < s.size(); ++i) {
-        if (s.at(i) == QLatin1Char('&'))
+        if (s.at(i) == QLatin1Char('&')) {
             s.remove(i, 1);
+        }
     }
     return s.trimmed();
 }
 
-void addShortcutToToolTip(QAction *action)
-{
-    if (!action->shortcut().isEmpty()) {
-        QString tooltip = action->property("tooltipBackup").toString();
-        if (tooltip.isEmpty()) {
-            tooltip = action->toolTip();
-            if (tooltip != strippedActionText(action->text())) {
-                action->setProperty(
-                    "tooltipBackup",
-                    action->toolTip()); // action uses a custom tooltip. Backup
-                                        // so that we can restore it later.
-            }
-        }
-        QColor shortcutTextColor =
-            QApplication::palette().color(QPalette::ToolTipText);
-        QString shortCutTextColorName;
-        if (shortcutTextColor.value() == 0) {
-            shortCutTextColorName =
-                "gray"; // special handling for black because lighter() does not
-                        // work there [QTBUG-9343].
-        } else {
-            int factor = (shortcutTextColor.value() < 128) ? 150 : 50;
-            shortCutTextColorName = shortcutTextColor.lighter(factor).name();
-        }
-        action->setToolTip(
-            QString("<p style='white-space:pre'>%1&nbsp;&nbsp;<code "
-                    "style='color:%2; font-size:small'>%3</code></p>")
-                .arg(tooltip, shortCutTextColorName,
-                     action->shortcut().toString(QKeySequence::NativeText)));
-    }
-}
-
-void removeShortcutFromToolTip(QAction *action)
-{
-    action->setToolTip(action->property("tooltipBackup").toString());
-    action->setProperty("tooltipBackup", QVariant());
-}
-
-// clang-format off
 // https://github.com/qt/qtbase/tree/ae2c30942086bd0387c6d5297c0cb85b505f29a0/src/corelib/time/qdatetime.cpp#L762
-static QDateTime toEarliest(QDate day, const QDateTime &form)
+QDateTime toEarliest(QDate day, const QDateTime &form)
 {
     const Qt::TimeSpec spec = form.timeSpec();
     const int offset = (spec == Qt::OffsetFromUTC) ? form.offsetFromUtc() : 0;
 #if QT_CONFIG(timezone)
     QTimeZone zone;
-    if (spec == Qt::TimeZone)
+    if (spec == Qt::TimeZone) {
         zone = form.timeZone();
+    }
 #endif
     auto moment = [=](QTime time) {
         switch (spec) {
@@ -90,16 +59,17 @@ static QDateTime toEarliest(QDate day, const QDateTime &form)
         if (!when.isValid()) {
             // ... unless it's a 24-hour jump (moving the date-line)
             when = moment(QTime(23, 59, 59, 999));
-            if (!when.isValid())
-                return QDateTime();
+            if (!when.isValid()) {
+                return {};
+            }
         }
     }
     int high = when.time().msecsSinceStartOfDay() / 60000;
     int low = 0;
     // Binary chop to the right minute
     while (high > low + 1) {
-        int mid = (high + low) / 2;
-        QDateTime probe = moment(QTime(mid / 60, mid % 60));
+        const int mid = (high + low) / 2;
+        const QDateTime probe = moment(QTime(mid / 60, mid % 60));
         if (probe.isValid() && probe.date() == day) {
             high = mid;
             when = probe;
@@ -109,12 +79,76 @@ static QDateTime toEarliest(QDate day, const QDateTime &form)
     }
     return when;
 }
-// clang-format on
+} // namespace
+
+void addShortcutToToolTip(QAction *action)
+{
+    if (!action->shortcut().isEmpty()) {
+        QString tooltip = action->property("tooltipBackup").toString();
+        if (tooltip.isEmpty()) {
+            tooltip = action->toolTip();
+            if (tooltip != strippedActionText(action->text())) {
+                action->setProperty(
+                    "tooltipBackup",
+                    action->toolTip()); // action uses a custom tooltip. Backup
+                                        // so that we can restore it later.
+            }
+        }
+        const QColor shortcutTextColor =
+            QApplication::palette().color(QPalette::ToolTipText);
+        QString shortCutTextColorName;
+        if (shortcutTextColor.value() == 0) {
+            shortCutTextColorName =
+                "gray"; // special handling for black because lighter() does not
+                        // work there [QTBUG-9343].
+        } else {
+            const int factor = (shortcutTextColor.value() < 128) ? 150 : 50;
+            shortCutTextColorName = shortcutTextColor.lighter(factor).name();
+        }
+        action->setToolTip(
+            QString("<p style='white-space:pre'>%1&nbsp;&nbsp;<code "
+                    "style='color:%2; font-size:small'>%3</code></p>")
+                .arg(tooltip, shortCutTextColorName,
+                     action->shortcut().toString(QKeySequence::NativeText)));
+    }
+}
+
+void removeShortcutFromToolTip(QAction *action)
+{
+    action->setToolTip(action->property("tooltipBackup").toString());
+    action->setProperty("tooltipBackup", {});
+}
 
 QDateTime startOfDay(const QDate &date)
 {
     QDateTime when(date, QTime(0, 0), Qt::LocalTime);
-    if (!when.isValid())
+    if (!when.isValid()) {
         when = toEarliest(date, when);
+    }
     return when.isValid() ? when : QDateTime();
+}
+
+bool isOkCancelOrder()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const int layout =
+        QApplication::style()->styleHint(QStyle::SH_DialogButtonLayout);
+    if (layout == static_cast<int>(Qt::LeftToRight)) {
+        return true;
+    }
+    return false;
+
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    const QStyle::LayoutDirection layout =
+        QApplication::style()->standardButtonLayout();
+
+    if (layout == QStyle::LeftToRight || layout == QStyle::WindowsLayout) {
+        return true;
+    }
+    return false;
+
+#else
+    // Fallback to "Cancel" is 1st
+    return false;
+#endif
 }

--- a/src/qtutil.hpp
+++ b/src/qtutil.hpp
@@ -19,4 +19,9 @@ void removeShortcutFromToolTip(QAction *action);
 /// See: https://doc.qt.io/qt-5/qdate.html#startOfDay
 QDateTime startOfDay(const QDate &);
 
+/**
+ * * @returns true if Ok-Cancel order of the buttons should be used (Ok/Positive
+ * is 1st).
+ */
+bool isOkCancelOrder();
 #endif // QTUTIL_HPP

--- a/src/recurringdialog.cpp
+++ b/src/recurringdialog.cpp
@@ -1,44 +1,50 @@
 #include "recurringdialog.hpp"
 
+#include <QAbstractItemView>
 #include <QCoreApplication>
+#include <QDialog>
+#include <QDialogButtonBox>
 #include <QHeaderView>
+#include <QIcon>
+#include <QList>
 #include <QTableView>
 #include <QVBoxLayout>
+#include <QWidget>
 
 #include "recurringtasksmodel.hpp"
+#include "task.hpp"
 
-RecurringDialog::RecurringDialog(const QList<RecurringTask> &tasks,
-                                 QWidget *parent)
+#include <utility>
+
+RecurringDialog::RecurringDialog(QList<RecurringTask> tasks, QWidget *parent)
     : QDialog(parent)
+    , m_tasks_view(new QTableView(this))
+    , m_btn_box(new QDialogButtonBox(
+          QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this))
 {
     setWindowTitle(QCoreApplication::applicationName() + " - Recurring tasks");
     setMinimumSize(500, 400);
-    initUI(tasks);
+    initUI(std::move(tasks));
 }
 
-RecurringDialog::~RecurringDialog() {}
+RecurringDialog::~RecurringDialog() = default;
 
-void RecurringDialog::initUI(const QList<RecurringTask> &tasks)
+void RecurringDialog::initUI(QList<RecurringTask> tasks)
 {
     setWindowIcon(QIcon(":/icons/qtask.svg"));
-
-    m_tasks_view = new QTableView(this);
     m_tasks_view->setShowGrid(true);
-
     m_tasks_view->verticalHeader()->setVisible(false);
     m_tasks_view->horizontalHeader()->setStretchLastSection(true);
     m_tasks_view->setSelectionBehavior(QAbstractItemView::SelectRows);
 
-    RecurringTasksModel *model = new RecurringTasksModel();
-    model->setTasks(tasks);
+    auto *model = new RecurringTasksModel();
+    model->setTasks(std::move(tasks));
     m_tasks_view->setModel(model);
 
-    m_btn_box =
-        new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     connect(m_btn_box, &QDialogButtonBox::accepted, this, &QDialog::accept);
     connect(m_btn_box, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
-    QVBoxLayout *main_layout = new QVBoxLayout();
+    auto *main_layout = new QVBoxLayout();
     main_layout->addWidget(m_tasks_view);
     main_layout->addWidget(m_btn_box);
     main_layout->setContentsMargins(5, 5, 5, 5);

--- a/src/recurringdialog.hpp
+++ b/src/recurringdialog.hpp
@@ -22,8 +22,8 @@ class RecurringDialog : public QDialog {
     void initUI(QList<RecurringTask> tasks);
 
   private:
-    QTableView *m_tasks_view;
-    QDialogButtonBox *m_btn_box;
+    QTableView *const m_tasks_view;
+    QDialogButtonBox *const m_btn_box;
 };
 
 #endif // RECURRINGDIALOG_HPP

--- a/src/recurringdialog.hpp
+++ b/src/recurringdialog.hpp
@@ -3,21 +3,23 @@
 
 #include <QDialog>
 #include <QDialogButtonBox>
+#include <QList>
+#include <QObject>
 #include <QTableView>
 #include <QWidget>
 
-#include "recurringtasksmodel.hpp"
 #include "task.hpp"
 
 class RecurringDialog : public QDialog {
     Q_OBJECT
 
   public:
-    RecurringDialog(const QList<RecurringTask> &, QWidget *parent = nullptr);
-    ~RecurringDialog();
+    explicit RecurringDialog(QList<RecurringTask> tasks,
+                             QWidget *parent = nullptr);
+    ~RecurringDialog() override;
 
   private:
-    void initUI(const QList<RecurringTask> &);
+    void initUI(QList<RecurringTask> tasks);
 
   private:
     QTableView *m_tasks_view;

--- a/src/recurringtasksmodel.cpp
+++ b/src/recurringtasksmodel.cpp
@@ -6,6 +6,8 @@
 #include <QList>
 #include <QVariant>
 
+#include <utility>
+
 RecurringTasksModel::RecurringTasksModel(QObject *parent)
     : QAbstractTableModel(parent)
     , m_tasks({})
@@ -40,14 +42,15 @@ QVariant RecurringTasksModel::data(const QModelIndex &index, int role) const
         }
     }
 
-    return QVariant();
+    return {};
 }
 
 bool RecurringTasksModel::setData(const QModelIndex &idx, const QVariant &value,
                                   int role)
 {
-    if (!idx.isValid())
+    if (!idx.isValid()) {
         return false;
+    }
 
     if (role == Qt::EditRole) {
         int row = idx.row();
@@ -61,8 +64,9 @@ QVariant RecurringTasksModel::headerData(int section,
                                          Qt::Orientation orientation,
                                          int role) const
 {
-    if (role != Qt::DisplayRole)
+    if (role != Qt::DisplayRole) {
         return {};
+    }
 
     if (orientation == Qt::Horizontal) {
         switch (section) {
@@ -80,16 +84,9 @@ QVariant RecurringTasksModel::headerData(int section,
     return {};
 }
 
-void RecurringTasksModel::setTasks(const QList<RecurringTask> &tasks)
+void RecurringTasksModel::setTasks(QList<RecurringTask> tasks)
 {
     beginResetModel();
-    m_tasks = tasks;
-    endResetModel();
-}
-
-void RecurringTasksModel::setTasks(QList<RecurringTask> &&tasks)
-{
-    beginResetModel();
-    m_tasks = tasks;
+    m_tasks = std::move(tasks);
     endResetModel();
 }

--- a/src/recurringtasksmodel.hpp
+++ b/src/recurringtasksmodel.hpp
@@ -23,8 +23,7 @@ class RecurringTasksModel : public QAbstractTableModel {
     QVariant headerData(int section, Qt::Orientation,
                         int role = Qt::DisplayRole) const override;
 
-    void setTasks(const QList<RecurringTask> &);
-    void setTasks(QList<RecurringTask> &&);
+    void setTasks(QList<RecurringTask> tasks);
 
   private:
     QList<RecurringTask> m_tasks;

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -1,6 +1,7 @@
 #include "settingsdialog.hpp"
 
 #include <QAbstractButton>
+#include <QCheckBox>
 #include <QCoreApplication>
 #include <QDialog>
 #include <QDialogButtonBox>
@@ -13,47 +14,50 @@
 
 SettingsDialog::SettingsDialog(QWidget *parent)
     : QDialog(parent)
+    , m_task_bin_edit(new QLineEdit(this))
+    , m_task_data_path_edit(new QLineEdit(this))
+    , m_hide_on_startup_cb(
+          new QCheckBox(tr("Hide QTask window on startup"), this))
+    , m_save_filter_on_exit(new QCheckBox(tr("Save task filter on exit"), this))
+    , m_buttons(new QDialogButtonBox(QDialogButtonBox::Ok |
+                                         QDialogButtonBox::Apply |
+                                         QDialogButtonBox::Close,
+                                     this))
+
 {
+    setWindowTitle(tr("Settings"));
+    setWindowIcon(QIcon(":/icons/qtask.svg"));
+
     initUI();
 }
 
-SettingsDialog::~SettingsDialog() {}
+SettingsDialog::~SettingsDialog() = default;
 
 void SettingsDialog::initUI()
 {
-    QGridLayout *main_layout = new QGridLayout();
+    auto *main_layout = new QGridLayout(this);
     main_layout->setContentsMargins(5, 5, 5, 5);
 
-    setWindowTitle(QCoreApplication::applicationName() + " - Settings");
-    setWindowIcon(QIcon(":/icons/qtask.svg"));
-
-    QLabel *task_bin_label = new QLabel("task executable:");
+    auto *task_bin_label = new QLabel(tr("task executable:"));
     main_layout->addWidget(task_bin_label, 0, 0);
 
-    m_task_bin_edit = new QLineEdit();
     m_task_bin_edit->setText(ConfigManager::config().getTaskBin());
     main_layout->addWidget(m_task_bin_edit, 0, 1);
 
-    QLabel *task_data_path_label = new QLabel("Path to task data:");
+    auto *task_data_path_label = new QLabel(tr("Path to task data:"));
     main_layout->addWidget(task_data_path_label, 1, 0);
 
-    m_task_data_path_edit = new QLineEdit();
     m_task_data_path_edit->setText(ConfigManager::config().getTaskDataPath());
     main_layout->addWidget(m_task_data_path_edit, 1, 1);
 
-    m_hide_on_startup_cb = new QCheckBox(tr("Hide QTask window on startup"));
     m_hide_on_startup_cb->setChecked(
         ConfigManager::config().getHideWindowOnStartup());
     main_layout->addWidget(m_hide_on_startup_cb, 2, 0, 1, 2);
 
-    m_save_filter_on_exit = new QCheckBox(tr("Save task filter on exit"));
     m_save_filter_on_exit->setChecked(
         ConfigManager::config().getSaveFilterOnExit());
     main_layout->addWidget(m_save_filter_on_exit, 3, 0, 1, 2);
 
-    m_buttons =
-        new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Apply |
-                             QDialogButtonBox::Close);
     connect(m_buttons, &QDialogButtonBox::clicked, this,
             &SettingsDialog::onButtonBoxClicked);
     main_layout->addWidget(m_buttons, 4, 0, 1, 2);
@@ -64,12 +68,14 @@ void SettingsDialog::initUI()
 void SettingsDialog::applySettings()
 {
     auto task_data_path = m_task_data_path_edit->text();
-    if (ConfigManager::config().getTaskDataPath() != task_data_path)
+    if (ConfigManager::config().getTaskDataPath() != task_data_path) {
         ConfigManager::config().setTaskDataPath(task_data_path);
+    }
 
     auto task_bin = m_task_bin_edit->text();
-    if (ConfigManager::config().getTaskBin() != task_bin)
+    if (ConfigManager::config().getTaskBin() != task_bin) {
         ConfigManager::config().setTaskBin(task_bin);
+    }
 
     ConfigManager::config().setHideWindowOnStartup(
         m_hide_on_startup_cb->isChecked());

--- a/src/settingsdialog.hpp
+++ b/src/settingsdialog.hpp
@@ -11,22 +11,21 @@ class SettingsDialog : public QDialog {
     Q_OBJECT
 
   public:
-    SettingsDialog(QWidget *parent = nullptr);
-    ~SettingsDialog();
-
-  private:
-    void initUI();
-    void applySettings();
+    explicit SettingsDialog(QWidget *parent = nullptr);
+    ~SettingsDialog() override;
 
   private slots:
     void onButtonBoxClicked(QAbstractButton *);
 
   private:
-    QLineEdit *m_task_bin_edit;
-    QLineEdit *m_task_data_path_edit;
-    QCheckBox *m_hide_on_startup_cb;
-    QCheckBox *m_save_filter_on_exit;
-    QDialogButtonBox *m_buttons;
+    void initUI();
+    void applySettings();
+
+    QLineEdit *const m_task_bin_edit;
+    QLineEdit *const m_task_data_path_edit;
+    QCheckBox *const m_hide_on_startup_cb;
+    QCheckBox *const m_save_filter_on_exit;
+    QDialogButtonBox *const m_buttons;
 };
 
 #endif // SETTINGSDIALOG_HPP

--- a/src/tagsedit.cpp
+++ b/src/tagsedit.cpp
@@ -14,6 +14,7 @@
 #include <QTextLayout>
 #include <QtGui/private/qinputcontrol_p.h>
 
+#include <algorithm>
 #include <cassert>
 #include <iterator>
 #include <memory>

--- a/src/taskdialog.cpp
+++ b/src/taskdialog.cpp
@@ -22,46 +22,12 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 #include <QWidget>
-#include <Qt>
 #include <qtmetamacros.h>
-#include <qtversionchecks.h>
 
 #include "optionaldatetimeedit.hpp"
 #include "qtutil.hpp"
 #include "tagsedit.hpp"
 #include "task.hpp"
-
-namespace
-{
-/**
- * * @returns true if Ok-Cancel order of the buttons should be used (Ok/Positive
- * is 1st).
- */
-bool IsOkCancelOrder()
-{
-#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
-    const int layout =
-        QApplication::style()->styleHint(QStyle::SH_DialogButtonLayout);
-    if (layout == static_cast<int>(Qt::LeftToRight)) {
-        return true;
-    }
-    return false;
-
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-    const QStyle::LayoutDirection layout =
-        QApplication::style()->standardButtonLayout();
-
-    if (layout == QStyle::LeftToRight || layout == QStyle::WindowsLayout) {
-        return true;
-    }
-    return false;
-
-#else
-    // Fallback to "Cancel" is 1st
-    return false;
-#endif
-}
-} // namespace
 
 TaskDialogBase::TaskDialogBase(QWidget *parent)
     : QDialog(parent)
@@ -168,7 +134,7 @@ QHBoxLayout *TaskDialogBase::Create3ButtonsLayout(QPushButton *positive_button,
                                                   QPushButton *mid_button)
 {
     auto *button_layout = new QHBoxLayout(this);
-    if (IsOkCancelOrder()) {
+    if (isOkCancelOrder()) {
         button_layout->addWidget(positive_button);
         button_layout->addWidget(mid_button);
         button_layout->addWidget(negative_button);

--- a/src/taskdialog.cpp
+++ b/src/taskdialog.cpp
@@ -2,32 +2,139 @@
 
 #include <QApplication>
 #include <QBoxLayout>
+#include <QChar>
+#include <QComboBox>
 #include <QCoreApplication>
 #include <QDateTime>
 #include <QDebug>
 #include <QDialog>
+#include <QGridLayout>
 #include <QImage>
+#include <QKeySequence>
 #include <QLabel>
 #include <QLineEdit>
 #include <QMessageBox>
+#include <QObject>
 #include <QPushButton>
 #include <QShortcut>
 #include <QStringList>
+#include <QStyle>
+#include <QTextEdit>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <Qt>
+#include <qtmetamacros.h>
+#include <qtversionchecks.h>
 
-#include "mainwindow.hpp"
 #include "optionaldatetimeedit.hpp"
 #include "qtutil.hpp"
+#include "tagsedit.hpp"
 #include "task.hpp"
-#include "tasksmodel.hpp"
 
-TaskDialog::TaskDialog(QWidget *parent)
-    : QDialog(parent)
+namespace
 {
+/**
+ * * @returns true if Ok-Cancel order of the buttons should be used (Ok/Positive
+ * is 1st).
+ */
+bool IsOkCancelOrder()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    const int layout =
+        QApplication::style()->styleHint(QStyle::SH_DialogButtonLayout);
+    if (layout == static_cast<int>(Qt::LeftToRight)) {
+        return true;
+    }
+    return false;
+
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+    const QStyle::LayoutDirection layout =
+        QApplication::style()->standardButtonLayout();
+
+    if (layout == QStyle::LeftToRight || layout == QStyle::WindowsLayout) {
+        return true;
+    }
+    return false;
+
+#else
+    // Fallback to "Cancel" is 1st
+    return false;
+#endif
+}
+} // namespace
+
+TaskDialogBase::TaskDialogBase(QWidget *parent)
+    : QDialog(parent)
+    , m_main_layout(new QVBoxLayout(this))
+    , m_task_description(new QTextEdit(this))
+    , m_task_priority(new QComboBox(this))
+    , m_task_project(new QLineEdit(this))
+    , m_task_tags(new TagsEdit(this))
+    , m_task_sched(new OptionalDateTimeEdit(tr("Schedule:"), this))
+    , m_task_due(new OptionalDateTimeEdit(tr("Due:"), this))
+    , m_task_wait(new OptionalDateTimeEdit(tr("Wait:"), this))
+    , m_task_uuid("")
+{
+    setWindowIcon(QIcon(":/icons/qtask.svg"));
+    constructUi();
 }
 
-Task TaskDialog::getTask()
+void TaskDialogBase::constructUi()
+{
+    auto *description_label = new QLabel(tr("Description:"), this);
+    m_task_description->setTabChangesFocus(true);
+    QObject::connect(m_task_description, &QTextEdit::textChanged, this,
+                     &TaskDialogBase::onDescriptionChanged);
+
+    auto *priority_label = new QLabel(tr("Priority:"), this);
+    m_task_priority->addItem("");
+    m_task_priority->addItem("L");
+    m_task_priority->addItem("M");
+    m_task_priority->addItem("H");
+
+    auto *project_label = new QLabel(tr("Project:"), this);
+
+    QObject::connect(m_task_project, &QLineEdit::editingFinished, this,
+                     [&]() { focusNextChild(); });
+
+    auto *tags_label = new QLabel(tr("Tags:"), this);
+
+    m_task_sched->setChecked(false);
+    // Taskwarrior's implementation feature
+    m_task_sched->setMinimumDateTime(startOfDay(QDate(1980, 1, 2)));
+    m_task_sched->setMaximumDateTime(startOfDay(QDate(2038, 1, 1)));
+    m_task_sched->setDateTime(startOfDay(QDate::currentDate()).addDays(1));
+
+    m_task_due->setChecked(false);
+    m_task_due->setMinimumDateTime(startOfDay(QDate(1980, 1, 2)));
+    m_task_due->setMaximumDateTime(startOfDay(QDate(2038, 1, 1)));
+    m_task_due->setDateTime(startOfDay(QDate::currentDate()).addDays(5));
+
+    m_task_wait->setChecked(false);
+    m_task_wait->setMinimumDateTime(startOfDay(QDate(1980, 1, 2)));
+    m_task_wait->setMaximumDateTime(startOfDay(QDate(2038, 1, 1)));
+    m_task_wait->setDateTime(startOfDay(QDate::currentDate()).addDays(5));
+
+    auto *grid_layout = new QGridLayout(this);
+    grid_layout->addWidget(priority_label, 0, 0);
+    grid_layout->addWidget(m_task_priority, 0, 1);
+    grid_layout->addWidget(project_label, 1, 0);
+    grid_layout->addWidget(m_task_project, 1, 1);
+    grid_layout->addWidget(tags_label, 2, 0);
+    grid_layout->addWidget(m_task_tags, 2, 1);
+    grid_layout->addWidget(m_task_sched, 3, 0, 1, 2);
+    grid_layout->addWidget(m_task_due, 4, 0, 1, 2);
+    grid_layout->addWidget(m_task_wait, 5, 0, 1, 2);
+
+    m_main_layout->addWidget(description_label);
+    m_main_layout->addWidget(m_task_description);
+    m_main_layout->addLayout(grid_layout);
+    m_main_layout->setContentsMargins(5, 5, 5, 5);
+
+    setLayout(m_main_layout);
+}
+
+Task TaskDialogBase::getTask()
 {
     Task task;
 
@@ -42,8 +149,9 @@ Task TaskDialog::getTask()
     for (const auto &tag : m_task_tags->getTags()) {
         QString t(tag);
         t.remove(QChar('+'));
-        if (!t.isEmpty())
+        if (!t.isEmpty()) {
             task.tags.push_back(t);
+        }
     }
 
     task.sched = m_task_sched->getDateTime();
@@ -53,7 +161,25 @@ Task TaskDialog::getTask()
     return task;
 }
 
-void TaskDialog::keyPressEvent(QKeyEvent *event)
+QHBoxLayout *TaskDialogBase::Create3ButtonsLayout(QPushButton *positive_button,
+                                                  QPushButton *negative_button,
+                                                  QPushButton *mid_button)
+{
+    auto *button_layout = new QHBoxLayout(this);
+    if (IsOkCancelOrder()) {
+        button_layout->addWidget(positive_button);
+        button_layout->addWidget(mid_button);
+        button_layout->addWidget(negative_button);
+
+    } else {
+        button_layout->addWidget(negative_button);
+        button_layout->addWidget(mid_button);
+        button_layout->addWidget(positive_button);
+    }
+    return button_layout;
+}
+
+void TaskDialogBase::keyPressEvent(QKeyEvent *event)
 {
     if (event == QKeySequence::Close) {
         reject();
@@ -62,71 +188,7 @@ void TaskDialog::keyPressEvent(QKeyEvent *event)
     }
 }
 
-void TaskDialog::initUI()
-{
-    setWindowIcon(QIcon(":/icons/qtask.svg"));
-
-    QLabel *description_label = new QLabel("Description:");
-    m_task_description = new QTextEdit();
-    m_task_description->setTabChangesFocus(true);
-    QObject::connect(m_task_description, &QTextEdit::textChanged, this,
-                     &TaskDialog::onDescriptionChanged);
-
-    QLabel *priority_label = new QLabel("Priority:");
-    m_task_priority = new QComboBox();
-    m_task_priority->addItem("");
-    m_task_priority->addItem("L");
-    m_task_priority->addItem("M");
-    m_task_priority->addItem("H");
-
-    QLabel *project_label = new QLabel("Project:");
-    m_task_project = new QLineEdit();
-    QObject::connect(m_task_project, &QLineEdit::editingFinished, this,
-                     [&]() { focusNextChild(); });
-
-    QLabel *tags_label = new QLabel("Tags:");
-    m_task_tags = new TagsEdit();
-
-    m_task_sched = new OptionalDateTimeEdit("Schedule:");
-    m_task_sched->setChecked(false);
-    // Taskwarrior's implementation feature
-    m_task_sched->setMinimumDateTime(startOfDay(QDate(1980, 1, 2)));
-    m_task_sched->setMaximumDateTime(startOfDay(QDate(2038, 1, 1)));
-    m_task_sched->setDateTime(startOfDay(QDate::currentDate()).addDays(1));
-
-    m_task_due = new OptionalDateTimeEdit("Due:");
-    m_task_due->setChecked(false);
-    m_task_due->setMinimumDateTime(startOfDay(QDate(1980, 1, 2)));
-    m_task_due->setMaximumDateTime(startOfDay(QDate(2038, 1, 1)));
-    m_task_due->setDateTime(startOfDay(QDate::currentDate()).addDays(5));
-
-    m_task_wait = new OptionalDateTimeEdit("Wait:");
-    m_task_wait->setChecked(false);
-    m_task_wait->setMinimumDateTime(startOfDay(QDate(1980, 1, 2)));
-    m_task_wait->setMaximumDateTime(startOfDay(QDate(2038, 1, 1)));
-    m_task_wait->setDateTime(startOfDay(QDate::currentDate()).addDays(5));
-
-    QGridLayout *grid_layout = new QGridLayout();
-    grid_layout->addWidget(priority_label, 0, 0);
-    grid_layout->addWidget(m_task_priority, 0, 1);
-    grid_layout->addWidget(project_label, 1, 0);
-    grid_layout->addWidget(m_task_project, 1, 1);
-    grid_layout->addWidget(tags_label, 2, 0);
-    grid_layout->addWidget(m_task_tags, 2, 1);
-    grid_layout->addWidget(m_task_sched, 3, 0, 1, 2);
-    grid_layout->addWidget(m_task_due, 4, 0, 1, 2);
-    grid_layout->addWidget(m_task_wait, 5, 0, 1, 2);
-
-    m_main_layout = new QVBoxLayout();
-    m_main_layout->addWidget(description_label);
-    m_main_layout->addWidget(m_task_description);
-    m_main_layout->addLayout(grid_layout);
-    m_main_layout->setContentsMargins(5, 5, 5, 5);
-
-    setLayout(m_main_layout);
-}
-
-void TaskDialog::setTask(const Task &task)
+void TaskDialogBase::setTask(const Task &task)
 {
     m_task_description->setText(task.description);
     m_task_project->setText(task.project);
@@ -155,29 +217,28 @@ void TaskDialog::setTask(const Task &task)
 }
 
 AddTaskDialog::AddTaskDialog(const QVariant &default_project, QWidget *parent)
-    : TaskDialog(parent)
+    : TaskDialogBase(parent)
+    , m_ok_btn(new QPushButton(
+          QApplication::style()->standardIcon(QStyle::SP_DialogOkButton),
+          tr("Ok"), this))
+    , m_continue_btn(new QPushButton(tr("Continue"), this))
 {
-    initUI();
-    if (!default_project.isNull())
+    setWindowTitle(tr("Add task"));
+    constructUi();
+    if (!default_project.isNull()) {
         m_task_project->setText(default_project.toString());
+    }
+    adjustSize();
 }
 
-void AddTaskDialog::initUI()
+void AddTaskDialog::constructUi()
 {
-    TaskDialog::initUI();
-    setWindowTitle(QCoreApplication::applicationName() + " - Add task");
-    Q_ASSERT(m_main_layout);
-
-    m_ok_btn = new QPushButton(
-        QApplication::style()->standardIcon(QStyle::SP_DialogOkButton),
-        tr("Ok"), this);
     m_ok_btn->setEnabled(false);
     auto *create_shortcut = new QShortcut(QKeySequence("Ctrl+Return"), this);
     QObject::connect(create_shortcut, &QShortcut::activated, this,
                      &QDialog::accept);
     m_ok_btn->setToolTip(tr("Create task"));
 
-    m_continue_btn = new QPushButton(tr("Continue"), this);
     m_continue_btn->setEnabled(false);
     auto *continue_shortcut = new QShortcut(QKeySequence("Alt+Return"), this);
     QObject::connect(continue_shortcut, &QShortcut::activated, this,
@@ -187,22 +248,18 @@ void AddTaskDialog::initUI()
     auto *cancel_btn = new QPushButton(
         QApplication::style()->standardIcon(QStyle::SP_DialogCancelButton),
         tr("Cancel"), this);
-    auto *cancel_shortcut = new QShortcut(QKeySequence("Escape"), this);
+    auto *cancel_shortcut = new QShortcut(QKeySequence::Cancel, this);
     QObject::connect(cancel_shortcut, &QShortcut::activated, this,
                      &QDialog::reject);
     cancel_btn->setToolTip(tr("Cancel and close this window"));
-
-    QBoxLayout *button_layout = new QHBoxLayout();
-    button_layout->addWidget(cancel_btn);
-    button_layout->addWidget(m_continue_btn);
-    button_layout->addWidget(m_ok_btn);
 
     connect(m_ok_btn, &QPushButton::clicked, this, &QDialog::accept);
     connect(m_continue_btn, &QPushButton::clicked, this,
             &AddTaskDialog::createTaskAndContinue);
     connect(cancel_btn, &QPushButton::clicked, this, &QDialog::reject);
 
-    m_main_layout->addLayout(button_layout);
+    m_main_layout->addLayout(
+        Create3ButtonsLayout(m_ok_btn, cancel_btn, m_continue_btn));
 }
 
 void AddTaskDialog::acceptContinue()
@@ -224,27 +281,24 @@ void AddTaskDialog::onDescriptionChanged()
 }
 
 EditTaskDialog::EditTaskDialog(const Task &task, QWidget *parent)
-    : TaskDialog(parent)
+    : TaskDialogBase(parent)
+    , m_ok_btn(new QPushButton(
+          QApplication::style()->standardIcon(QStyle::SP_DialogOkButton),
+          tr("Ok"), this))
+    , m_delete_btn(new QPushButton(tr("Delete"), this))
 {
-    setWindowTitle(QCoreApplication::applicationName() + " - Edit task");
-    initUI();
+    setWindowTitle(tr("Edit task"));
+    constructUi();
     setTask(task);
 }
 
-void EditTaskDialog::initUI()
+void EditTaskDialog::constructUi()
 {
-    TaskDialog::initUI();
-    Q_ASSERT(m_main_layout);
-
-    m_ok_btn = new QPushButton(
-        QApplication::style()->standardIcon(QStyle::SP_DialogOkButton),
-        tr("Ok"), this);
     auto *create_shortcut = new QShortcut(QKeySequence("Ctrl+Return"), this);
     QObject::connect(create_shortcut, &QShortcut::activated, this,
                      &QDialog::accept);
     m_ok_btn->setToolTip(tr("Create task"));
 
-    m_delete_btn = new QPushButton(tr("Delete"), this);
     auto *delete_shortcut = new QShortcut(QKeySequence("Ctrl+Delete"), this);
     QObject::connect(delete_shortcut, &QShortcut::activated, this,
                      &EditTaskDialog::requestDeleteTask);
@@ -253,30 +307,25 @@ void EditTaskDialog::initUI()
     auto *cancel_btn = new QPushButton(
         QApplication::style()->standardIcon(QStyle::SP_DialogCancelButton),
         tr("Cancel"), this);
-    auto *cancel_shortcut = new QShortcut(QKeySequence("Escape"), this);
+    auto *cancel_shortcut = new QShortcut(QKeySequence::Cancel, this);
     QObject::connect(cancel_shortcut, &QShortcut::activated, this,
                      &QDialog::reject);
     cancel_btn->setToolTip(tr("Cancel and close this window"));
-
-    QBoxLayout *button_layout = new QHBoxLayout();
-    button_layout->addWidget(cancel_btn);
-    button_layout->addWidget(m_delete_btn);
-    button_layout->addWidget(m_ok_btn);
 
     connect(m_ok_btn, &QPushButton::clicked, this, &QDialog::accept);
     connect(m_delete_btn, &QPushButton::clicked, this,
             &EditTaskDialog::requestDeleteTask);
     connect(cancel_btn, &QPushButton::clicked, this, &QDialog::reject);
 
-    m_main_layout->addLayout(button_layout);
+    m_main_layout->addLayout(
+        Create3ButtonsLayout(m_ok_btn, cancel_btn, m_delete_btn));
 }
 
 void EditTaskDialog::requestDeleteTask()
 {
-    QMessageBox::StandardButton reply;
-    reply = QMessageBox::question(this, tr("Conifrm action"),
-                                  tr("Delete task #%1?").arg(m_task_uuid),
-                                  QMessageBox::Yes | QMessageBox::No);
+    auto reply = QMessageBox::question(this, tr("Conifrm action"),
+                                       tr("Delete task #%1?").arg(m_task_uuid),
+                                       QMessageBox::Yes | QMessageBox::No);
     if (reply == QMessageBox::Yes) {
         emit deleteTask(m_task_uuid);
         reject();

--- a/src/taskdialog.cpp
+++ b/src/taskdialog.cpp
@@ -79,6 +79,8 @@ TaskDialogBase::TaskDialogBase(QWidget *parent)
     constructUi();
 }
 
+TaskDialogBase::~TaskDialogBase() = default;
+
 void TaskDialogBase::constructUi()
 {
     auto *description_label = new QLabel(tr("Description:"), this);
@@ -231,6 +233,8 @@ AddTaskDialog::AddTaskDialog(const QVariant &default_project, QWidget *parent)
     adjustSize();
 }
 
+AddTaskDialog::~AddTaskDialog() = default;
+
 void AddTaskDialog::constructUi()
 {
     m_ok_btn->setEnabled(false);
@@ -290,6 +294,8 @@ EditTaskDialog::EditTaskDialog(const Task &task, QWidget *parent)
     constructUi();
     setTask(task);
 }
+
+EditTaskDialog::~EditTaskDialog() = default;
 
 void EditTaskDialog::constructUi()
 {

--- a/src/taskdialog.cpp
+++ b/src/taskdialog.cpp
@@ -234,23 +234,22 @@ AddTaskDialog::AddTaskDialog(const QVariant &default_project, QWidget *parent)
 void AddTaskDialog::constructUi()
 {
     m_ok_btn->setEnabled(false);
-    auto *create_shortcut = new QShortcut(QKeySequence("Ctrl+Return"), this);
-    QObject::connect(create_shortcut, &QShortcut::activated, this,
-                     &QDialog::accept);
+    QObject::connect(new QShortcut(QKeySequence("Ctrl+Return"), this),
+                     &QShortcut::activated, this, &QDialog::accept);
     m_ok_btn->setToolTip(tr("Create task"));
 
     m_continue_btn->setEnabled(false);
-    auto *continue_shortcut = new QShortcut(QKeySequence("Alt+Return"), this);
-    QObject::connect(continue_shortcut, &QShortcut::activated, this,
+    QObject::connect(new QShortcut(QKeySequence("Alt+Return"), this),
+                     &QShortcut::activated, this,
                      &AddTaskDialog::createTaskAndContinue);
     m_continue_btn->setToolTip(tr("Create task and continue"));
 
     auto *cancel_btn = new QPushButton(
         QApplication::style()->standardIcon(QStyle::SP_DialogCancelButton),
         tr("Cancel"), this);
-    auto *cancel_shortcut = new QShortcut(QKeySequence::Cancel, this);
-    QObject::connect(cancel_shortcut, &QShortcut::activated, this,
-                     &QDialog::reject);
+
+    QObject::connect(new QShortcut(QKeySequence::Cancel, this),
+                     &QShortcut::activated, this, &QDialog::reject);
     cancel_btn->setToolTip(tr("Cancel and close this window"));
 
     connect(m_ok_btn, &QPushButton::clicked, this, &QDialog::accept);
@@ -294,22 +293,20 @@ EditTaskDialog::EditTaskDialog(const Task &task, QWidget *parent)
 
 void EditTaskDialog::constructUi()
 {
-    auto *create_shortcut = new QShortcut(QKeySequence("Ctrl+Return"), this);
-    QObject::connect(create_shortcut, &QShortcut::activated, this,
-                     &QDialog::accept);
+    QObject::connect(new QShortcut(QKeySequence("Ctrl+Return"), this),
+                     &QShortcut::activated, this, &QDialog::accept);
     m_ok_btn->setToolTip(tr("Create task"));
 
-    auto *delete_shortcut = new QShortcut(QKeySequence("Ctrl+Delete"), this);
-    QObject::connect(delete_shortcut, &QShortcut::activated, this,
+    QObject::connect(new QShortcut(QKeySequence("Ctrl+Delete"), this),
+                     &QShortcut::activated, this,
                      &EditTaskDialog::requestDeleteTask);
     m_delete_btn->setToolTip(tr("Delete this task"));
 
     auto *cancel_btn = new QPushButton(
         QApplication::style()->standardIcon(QStyle::SP_DialogCancelButton),
         tr("Cancel"), this);
-    auto *cancel_shortcut = new QShortcut(QKeySequence::Cancel, this);
-    QObject::connect(cancel_shortcut, &QShortcut::activated, this,
-                     &QDialog::reject);
+    QObject::connect(new QShortcut(QKeySequence::Cancel, this),
+                     &QShortcut::activated, this, &QDialog::reject);
     cancel_btn->setToolTip(tr("Cancel and close this window"));
 
     connect(m_ok_btn, &QPushButton::clicked, this, &QDialog::accept);

--- a/src/taskdialog.hpp
+++ b/src/taskdialog.hpp
@@ -21,7 +21,7 @@ class TaskDialogBase : public QDialog {
     Q_OBJECT
   public:
     explicit TaskDialogBase(QWidget *parent = nullptr);
-    ~TaskDialogBase() override = default;
+    ~TaskDialogBase() override;
     TaskDialogBase(const TaskDialogBase &) = delete;
     TaskDialogBase &operator=(const TaskDialogBase &) = delete;
     TaskDialogBase(TaskDialogBase &&) = delete;
@@ -62,7 +62,7 @@ class AddTaskDialog final : public TaskDialogBase {
   public:
     explicit AddTaskDialog(const QVariant &default_project = {},
                            QWidget *parent = nullptr);
-    ~AddTaskDialog() final = default;
+    ~AddTaskDialog() final;
 
   public slots:
     void acceptContinue();
@@ -84,7 +84,7 @@ class EditTaskDialog final : public TaskDialogBase {
     Q_OBJECT
   public:
     explicit EditTaskDialog(const Task &, QWidget *parent = nullptr);
-    ~EditTaskDialog() final = default;
+    ~EditTaskDialog() final;
 
   signals:
     void deleteTask(const QString &uuid);

--- a/src/taskdialog.hpp
+++ b/src/taskdialog.hpp
@@ -6,59 +6,63 @@
 #include <QDateTimeEdit>
 #include <QDialog>
 #include <QKeyEvent>
+#include <QObject>
 #include <QPushButton>
+#include <QString>
 #include <QTextEdit>
 #include <QWidget>
+#include <qtmetamacros.h>
 
 #include "optionaldatetimeedit.hpp"
 #include "tagsedit.hpp"
 #include "task.hpp"
-#include "taskwarrior.hpp"
 
-class TaskDialog : public QDialog {
+class TaskDialogBase : public QDialog {
     Q_OBJECT
-
   public:
-    explicit TaskDialog(QWidget *parent = nullptr);
-    virtual ~TaskDialog() = default;
+    explicit TaskDialogBase(QWidget *parent = nullptr);
+    ~TaskDialogBase() override = default;
+    TaskDialogBase(const TaskDialogBase &) = delete;
+    TaskDialogBase &operator=(const TaskDialogBase &) = delete;
+    TaskDialogBase(TaskDialogBase &&) = delete;
+    TaskDialogBase &operator=(TaskDialogBase &&) = delete;
 
     Task getTask();
-
-  protected:
-    void keyPressEvent(QKeyEvent *) override;
-
-    void initUI();
-    void setTask(const Task &task);
 
   protected slots:
     virtual void onDescriptionChanged() = 0;
 
   protected:
-    QVBoxLayout *m_main_layout;
-    QTextEdit *m_task_description;
-    QComboBox *m_task_priority;
-    QLineEdit *m_task_project;
-    TagsEdit *m_task_tags;
-    OptionalDateTimeEdit *m_task_sched;
-    OptionalDateTimeEdit *m_task_due;
-    OptionalDateTimeEdit *m_task_wait;
+    // Create horizontal layout of 3 buttons. Positive and negative buttons are
+    // aligned according to the system (desktop) settings.
+    QHBoxLayout *Create3ButtonsLayout(QPushButton *positive_button,
+                                      QPushButton *negative_button,
+                                      QPushButton *mid_button);
 
-    QString m_task_uuid = "";
+    void keyPressEvent(QKeyEvent *) override;
+    void setTask(const Task &task);
+
+    QVBoxLayout *const m_main_layout;
+    QTextEdit *const m_task_description;
+    QComboBox *const m_task_priority;
+    QLineEdit *const m_task_project;
+    TagsEdit *const m_task_tags;
+    OptionalDateTimeEdit *const m_task_sched;
+    OptionalDateTimeEdit *const m_task_due;
+    OptionalDateTimeEdit *const m_task_wait;
+    QString m_task_uuid;
+
+  private:
+    void constructUi();
 };
 
-class AddTaskDialog final : public TaskDialog {
+class AddTaskDialog final : public TaskDialogBase {
     Q_OBJECT
 
   public:
     explicit AddTaskDialog(const QVariant &default_project = {},
                            QWidget *parent = nullptr);
-    ~AddTaskDialog() = default;
-
-  protected slots:
-    void onDescriptionChanged() override;
-
-  private:
-    void initUI();
+    ~AddTaskDialog() final = default;
 
   public slots:
     void acceptContinue();
@@ -66,31 +70,34 @@ class AddTaskDialog final : public TaskDialog {
   signals:
     void createTaskAndContinue();
 
+  protected slots:
+    void onDescriptionChanged() final;
+
   private:
-    QPushButton *m_ok_btn;
-    QPushButton *m_continue_btn;
+    void constructUi();
+
+    QPushButton *const m_ok_btn;
+    QPushButton *const m_continue_btn;
 };
 
-class EditTaskDialog final : public TaskDialog {
+class EditTaskDialog final : public TaskDialogBase {
     Q_OBJECT
-
   public:
     explicit EditTaskDialog(const Task &, QWidget *parent = nullptr);
-    ~EditTaskDialog() = default;
-
-  protected slots:
-    void onDescriptionChanged() override;
-
-  private:
-    void initUI();
-    void requestDeleteTask();
+    ~EditTaskDialog() final = default;
 
   signals:
     void deleteTask(const QString &uuid);
 
+  protected slots:
+    void onDescriptionChanged() final;
+
   private:
-    QPushButton *m_ok_btn;
-    QPushButton *m_delete_btn;
+    void constructUi();
+    void requestDeleteTask();
+
+    QPushButton *const m_ok_btn;
+    QPushButton *const m_delete_btn;
 };
 
 #endif // TASKDIALOG_HPP

--- a/src/tasksmodel.hpp
+++ b/src/tasksmodel.hpp
@@ -24,8 +24,7 @@ class TasksModel : public QAbstractTableModel {
     QVariant headerData(int section, Qt::Orientation,
                         int role = Qt::DisplayRole) const override;
 
-    void setTasks(const QList<Task> &);
-    void setTasks(QList<Task> &&);
+    void setTasks(QList<Task>);
     QVariant getTask(const QModelIndex &) const;
 
     QColor rowColor(int row) const;

--- a/src/tasksview.cpp
+++ b/src/tasksview.cpp
@@ -1,11 +1,17 @@
 #include "tasksview.hpp"
 
 #include <QApplication>
+#include <QCursor>
 #include <QDebug>
 #include <QModelIndex>
 #include <QMouseEvent>
+#include <QObject>
+#include <QPoint>
 #include <QTableView>
+#include <QWidget>
+#include <qnamespace.h>
 
+#include "task.hpp"
 #include "taskdescriptiondelegate.hpp"
 #include "tasksmodel.hpp"
 
@@ -20,7 +26,7 @@ void TasksView::mousePressEvent(QMouseEvent *event)
 {
     constexpr int project_column = 1;
 
-    QModelIndex idx = indexAt(event->pos());
+    const auto idx = indexAt(event->pos());
 
     // Enable "stop" button if the selected task is active
     if (idx.isValid() && event->buttons() & Qt::LeftButton) {
@@ -35,8 +41,9 @@ void TasksView::mousePressEvent(QMouseEvent *event)
     if (idx.isValid() && idx.column() == project_column &&
         event->buttons() & Qt::RightButton) {
         auto d = idx.data();
-        if (!d.isNull())
+        if (!d.isNull()) {
             emit pushProjectFilter("pro:" + d.toString());
+        }
     }
 
     auto anchor = anchorAt(event->pos());
@@ -82,10 +89,12 @@ void TasksView::mouseReleaseEvent(QMouseEvent *event)
 
 QString TasksView::anchorAt(const QPoint &pos) const
 {
-    auto index = indexAt(pos);
+    const auto index = indexAt(pos);
     if (index.isValid()) {
-        auto delegate = itemDelegate(index);
-        auto task_delegate = qobject_cast<TaskDescriptionDelegate *>(delegate);
+        const auto delegate = itemDelegate(index);
+        const auto task_delegate =
+            qobject_cast<TaskDescriptionDelegate *>(delegate);
+
         if (task_delegate) {
             auto item_rect = visualRect(index);
             auto relative_click_position = pos - item_rect.topLeft();
@@ -94,5 +103,5 @@ QString TasksView::anchorAt(const QPoint &pos) const
         }
     }
 
-    return QString();
+    return {};
 }

--- a/src/taskwarriorreferencedialog.cpp
+++ b/src/taskwarriorreferencedialog.cpp
@@ -10,13 +10,14 @@
 TaskwarriorReferenceDialog::TaskwarriorReferenceDialog(QWidget *parent)
     : QDialog(parent)
 {
+    setWindowTitle(tr("Taskwarrior Quick Reference"));
     initUI();
 }
 
+TaskwarriorReferenceDialog::~TaskwarriorReferenceDialog() = default;
+
 void TaskwarriorReferenceDialog::initUI()
 {
-    setWindowTitle(QCoreApplication::applicationName() +
-                   " - Taskwarrior quick reference");
 
     const auto group = QPalette::Active;
     const auto role = QPalette::Window;
@@ -69,8 +70,8 @@ void TaskwarriorReferenceDialog::initUI()
                 "</body></html>")
             .arg(c1.name(), c2.name());
 
-    QVBoxLayout *main_layout = new QVBoxLayout();
-    QLabel *info_label = new QLabel(info);
+    auto *main_layout = new QVBoxLayout(this);
+    auto *info_label = new QLabel(info, this);
     info_label->setOpenExternalLinks(true);
     info_label->setTextInteractionFlags(Qt::TextBrowserInteraction);
     main_layout->addWidget(info_label);

--- a/src/taskwarriorreferencedialog.hpp
+++ b/src/taskwarriorreferencedialog.hpp
@@ -7,7 +7,7 @@
 class TaskwarriorReferenceDialog : public QDialog {
   public:
     explicit TaskwarriorReferenceDialog(QWidget *parent = nullptr);
-    ~TaskwarriorReferenceDialog() = default;
+    ~TaskwarriorReferenceDialog() override;
 
   private:
     void initUI();

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -3,9 +3,17 @@
 #include <QDir>
 #include <QFile>
 #include <QFileSystemWatcher>
+#include <QObject>
 #include <QString>
+#include <QStringList>
 
-TaskWatcher::TaskWatcher(QObject *parent) {}
+#include <algorithm>
+#include <memory>
+
+TaskWatcher::TaskWatcher(QObject *parent)
+    : QObject(parent)
+{
+}
 
 TaskWatcher::~TaskWatcher() = default;
 

--- a/src/trayicon.cpp
+++ b/src/trayicon.cpp
@@ -1,20 +1,23 @@
 #include "trayicon.hpp"
 
-#include <QSystemTrayIcon>
 #include <QAction>
 #include <QMenu>
+#include <QObject>
 #include <QPixmap>
+#include <QSystemTrayIcon>
 
 using namespace ui;
 
-SystemTrayIcon::SystemTrayIcon(QObject *parent) :
-    QSystemTrayIcon(parent),
-    tray_icon_menu_(new QMenu())
+SystemTrayIcon::SystemTrayIcon(QObject *parent)
+    : QSystemTrayIcon(parent)
+    , tray_icon_menu_(new QMenu())
 {
-    //tray_icon_menu_ takes ownership.
-    const auto add_task_action_ = new QAction("Add &task", tray_icon_menu_.get());
-    const auto mute_notifications_action_ = new QAction("&Mute notifications", tray_icon_menu_.get());
-    const auto exit_action_ = new QAction("Quit", tray_icon_menu_.get());
+    // tray_icon_menu_ takes ownership.
+    const auto add_task_action_ =
+        new QAction(tr("Add &task"), tray_icon_menu_.get());
+    const auto mute_notifications_action_ =
+        new QAction(tr("&Mute notifications"), tray_icon_menu_.get());
+    const auto exit_action_ = new QAction(tr("&Quit"), tray_icon_menu_.get());
 
     tray_icon_menu_->addAction(add_task_action_);
     tray_icon_menu_->addSeparator();
@@ -30,5 +33,5 @@ SystemTrayIcon::SystemTrayIcon(QObject *parent) :
 
     setContextMenu(tray_icon_menu_.get());
     setIcon(QPixmap(":/icons/qtask.svg"));
-    setToolTip("QTask");
+    setToolTip(tr("QTask"));
 }


### PR DESCRIPTION
I've read all dialogs manually and added missing `parent` parameter in ctor calls, so objects allocated would be deleted properly.

In add/edit dialog I added the check of "Ok/Cancel" buttons order, now it will respect system configured.

Things related to actions in main window are revised. For example, common actions like "Delete" or "Find" will use system wide shortcut instead hard coded.

Many `clang-tidy` complains are fixed.

In general, I expect no functional changes here, but refactoring and proper memory management.