### PR TITLE
Add tooltip

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(qtask CXX)
 
 set(QTASK_VERSION_MAJOR 1)
 set(QTASK_VERSION_MINOR 1)
-set(QTASK_VERSION_PATCH 6)
+set(QTASK_VERSION_PATCH 7)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -18,30 +18,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
 
-option(BUILD_TESTS "Build tests" OFF)
-
-#Detect best qt version in the system.
-find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core Widgets)
-if (${QT_VERSION} VERSION_LESS 5.15.0)
-  find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
-else()
-  #Not sure, if should search/link GuiPrivate Svg with old versions.
-  find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets GuiPrivate Svg)
-find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
-endif()
-
-message(STATUS "Found Qt version ${QT_VERSION}.")
-
-if(${QT_VERSION} VERSION_LESS 5.3.0)
-  message(FATAL_ERROR "Found Qt version ${QT_VERSION} is too small.")
-endif()
-
-message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(DEBUG_MODE 1)
-else()
-  set(DEBUG_MODE 0)
-endif()
+option(BUILD_TESTS "Build tests." OFF)
 
 # To activate clazy: cmake . -DENABLE_CLAZY -DCMAKE_CXX_COMPILER=clazy
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}"
@@ -66,6 +43,25 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}"
   endif()
 endif()
 
+# List of Qt components we will need to find. Note, there is linking list below yet.
+set(QT_COMPONENTS_WE_NEED Core Widgets Concurrent GuiPrivate Svg)
+
+# Detect best qt version in the system.
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS ${QT_COMPONENTS_WE_NEED})
+message(STATUS "Found Qt version ${QT_VERSION}.")
+if(${QT_VERSION} VERSION_LESS 5.3.0)
+  message(FATAL_ERROR "Found Qt version ${QT_VERSION} is too small.")
+endif()
+# Bind tools to the version if both found, list must be the same in 2 calls.
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${QT_COMPONENTS_WE_NEED})
+
+message(STATUS "Build type: " ${CMAKE_BUILD_TYPE})
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(DEBUG_MODE 1)
+else()
+  set(DEBUG_MODE 0)
+endif()
+
 #List and add all files by mask to the project, no manual enlisting is required.
 file(GLOB qtask_SRCS
         src/*.h
@@ -78,18 +74,28 @@ set(qtask_MOC_HEADERS src/configmanager.hpp)
 set(qtask_RESOURCES res/qtask.qrc)
 add_executable(qtask ${qtask_SRCS} ${qtask_RESOURCES})
 
-target_link_libraries(qtask Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::GuiPrivate)
-if (${QT_VERSION} VERSION_GREATER_EQUAL 5.15.0)
-  target_link_libraries(qtask Qt${QT_VERSION_MAJOR}::Svg)
-endif()
-
 # Replacement of the QtSingleApplication for Qt5 and Qt6.
 set(QAPPLICATION_CLASS
     QApplication
     CACHE STRING "Inheritance class for SingleApplication")
 add_subdirectory(src/third-party/singleapplication)
+
+# Linking Qt components we found. This is a little tricky depending on major version used.
+target_link_libraries(qtask
+             Qt::Core
+             Qt::Widgets
+             Qt::Concurrent
+             SingleApplication::SingleApplication
+             Qt${QT_VERSION_MAJOR}::GuiPrivate # "Private" requires explicit version mention.
+)
+# Fallback to the historical code, linkage was not needed all years before. Cannot check in 2025.
+# Delete if () in case you have problems with missing Svg module.
+if (${QT_VERSION} VERSION_GREATER_EQUAL 5.15.0)
+  target_link_libraries(qtask Qt::Svg)
+endif()
+
+
 target_link_libraries(qtask SingleApplication::SingleApplication)
-target_link_libraries(qtask Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets)
 
 
 set(GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/gen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(qtask CXX)
 
@@ -27,6 +27,7 @@ if (${QT_VERSION} VERSION_LESS 5.15.0)
 else()
   #Not sure, if should search/link GuiPrivate Svg with old versions.
   find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets GuiPrivate Svg)
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Core Widgets)
 endif()
 
 message(STATUS "Found Qt version ${QT_VERSION}.")
@@ -88,6 +89,7 @@ set(QAPPLICATION_CLASS
     CACHE STRING "Inheritance class for SingleApplication")
 add_subdirectory(src/third-party/singleapplication)
 target_link_libraries(qtask SingleApplication::SingleApplication)
+target_link_libraries(qtask Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Widgets)
 
 
 set(GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/gen)

--- a/src/async_task_loader.hpp
+++ b/src/async_task_loader.hpp
@@ -32,7 +32,7 @@ class AsyncTaskLoader : public QObject {
     AsyncTaskLoader() = delete;
 
     template <typename taUserParameters>
-    RequestId startTaskLoad(taUserParameters &&userParameters,
+    RequestId startTaskLoad(taUserParameters userParameters,
                             const DetailedTaskInfo &partialTask)
     {
         const auto currentRequestId = ++m_latestRequestId;

--- a/src/async_task_loader.hpp
+++ b/src/async_task_loader.hpp
@@ -63,7 +63,9 @@ class AsyncTaskLoader : public QObject {
                 try {
                     // Note, use ONLY reading outside class Taskwarrior
                     // otherwise UNDO will be broken.
-                    const TaskWarriorExecutor executor(pathToBinary);
+                    const TaskWarriorExecutor executor(
+                        pathToBinary,
+                        TaskWarriorExecutor::TSkipBinaryValidation{});
                     DetailedTaskInfo task(sourceTask.task_id);
                     task.execReadExisting(executor);
                     return task;

--- a/src/async_task_loader.hpp
+++ b/src/async_task_loader.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <QFuture>
+#include <QFutureWatcher>
+#include <QMap>
+#include <QObject>
+#include <QString>
+#include <QtConcurrent>
+
+#include "configmanager.hpp"
+#include "task.hpp"
+#include "taskwarriorexecutor.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <limits>
+#include <utility>
+
+/// @brief Loads task asynchroniously.
+/// @note It does `task information`.
+class AsyncTaskLoader : public QObject {
+    Q_OBJECT
+  public:
+    using RequestId = std::size_t;
+    static constexpr auto kInvalidRequestId =
+        std::numeric_limits<RequestId>::max();
+
+    static AsyncTaskLoader *create(QObject *parent = nullptr)
+    {
+        return new AsyncTaskLoader(parent);
+    }
+    AsyncTaskLoader() = delete;
+
+    template <typename taUserParameters>
+    RequestId startTaskLoad(taUserParameters &&userParameters,
+                            const DetailedTaskInfo &partialTask)
+    {
+        const auto currentRequestId = ++m_latestRequestId;
+        auto *watcher = new TaskFutWatcher(this);
+        m_activeWatchers.insert(currentRequestId, watcher);
+
+        // Lambda will be called in GUI thread.
+        connect(watcher, &QFutureWatcher<DetailedTaskInfo>::finished, this,
+                [this, currentRequestId, watcher,
+                 userParameters = std::move(userParameters)]() {
+                    const auto loadedTask = watcher->future().result();
+                    if (currentRequestId >= m_latestRequestId.load()) {
+                        emit latestLoadingFinished(
+                            QVariant::fromValue(std::move(userParameters)),
+                            currentRequestId, loadedTask);
+                    }
+                    emit anyLoadingFinished(currentRequestId, loadedTask);
+
+                    // Clean-up, remove stored watcher.
+                    m_activeWatchers.remove(currentRequestId);
+                    watcher->deleteLater();
+                });
+
+        // Launching thread.
+        static const auto fetchTaskInfo =
+            [](const QString &pathToBinary,
+               const DetailedTaskInfo &sourceTask) {
+                try {
+                    // Note, use ONLY reading outside class Taskwarrior
+                    // otherwise UNDO will be broken.
+                    const TaskWarriorExecutor executor(pathToBinary);
+                    DetailedTaskInfo task(sourceTask.task_id);
+                    task.execReadExisting(executor);
+                    return task;
+                } catch (...) { // NOLINT
+                }
+                return sourceTask;
+            };
+        const QFuture<DetailedTaskInfo> future = QtConcurrent::run(
+            fetchTaskInfo, ConfigManager::config().getTaskBin(), partialTask);
+        watcher->setFuture(future);
+
+        return currentRequestId;
+    }
+
+  signals:
+    /// @brief Signal sent when we thing we finished latest requested loading if
+    /// it was many.
+    void latestLoadingFinished(QVariant userParams, RequestId requestId,
+                               DetailedTaskInfo result);
+    /// @brief Signal is sent for any loading finished (including latest one).
+    void anyLoadingFinished(RequestId requestId, DetailedTaskInfo result);
+
+  private:
+    using TaskFutWatcher = QFutureWatcher<DetailedTaskInfo>;
+    explicit AsyncTaskLoader(QObject *parent = nullptr)
+        : QObject{ parent }
+    {
+    }
+
+    std::atomic<RequestId> m_latestRequestId{ 0u };
+    QMap<RequestId, TaskFutWatcher *> m_activeWatchers;
+};

--- a/src/configmanager.cpp
+++ b/src/configmanager.cpp
@@ -29,52 +29,6 @@ QString expandHome(const QString &p)
     }
     return p;
 }
-
-/// @brief New taskwarior uses SQL data base, config files and db could be
-/// moved.
-/// @returns path to folder which contains binary task data.
-QString FindTaskDataFolder()
-{
-    static const std::vector<QString> kPossiblePath = {
-        QString("%1%2%3%2").arg(QDir::homePath(), QDir::separator(), ".task"),
-        QString("%1%2.config%2task%2taskrc")
-            .arg(QDir::homePath(), QDir::separator()),
-    };
-    const auto it =
-        std::find_if(kPossiblePath.begin(), kPossiblePath.end(),
-                     [](const auto &str) { return QFile::exists(str); });
-    if (it == kPossiblePath.end()) {
-        std::cerr << "Could not find predefined files with settings. Using old "
-                     "default value."
-                  << std::endl;
-        return kPossiblePath.front();
-    }
-    std::ifstream taskConf(it->toStdString());
-
-    // Checking no more than linesToCheck inside the file if it has proper path.
-    int linesToCheck = 100;
-    for (const auto line : per_line_stream(taskConf)) // NOLINT
-    {
-        if (linesToCheck-- < 0) {
-            std::cerr << "Nothing found in: " << it->toStdString() << std::endl;
-            break;
-        }
-        auto keyValue = QString::fromStdString(line).split("=");
-        keyValue.back() = expandHome(keyValue.back().trimmed());
-
-        if (keyValue.size() == 2 &&
-            keyValue.front().trimmed() == "data.location" &&
-            QDir(keyValue.back()).exists()) {
-            std::cout << "Found data location: "
-                      << keyValue.back().toStdString() << std::endl;
-            return std::move(keyValue.back());
-        }
-    }
-
-    std::cerr << "Could not find data file location. Assuming old taskwarriror."
-              << std::endl;
-    return *it;
-}
 } // namespace
 
 ConfigManager::ConfigManager(QObject *parent)
@@ -82,7 +36,6 @@ ConfigManager::ConfigManager(QObject *parent)
     , m_is_new(false)
     , m_config_path("")
     , m_task_bin(s_default_task_bin)
-    , m_task_data_path(FindTaskDataFolder())
     , m_show_task_shell(false)
     , m_hide_on_startup(false)
     , m_save_filter_on_exit(false)
@@ -147,7 +100,6 @@ void ConfigManager::updateConfigFile()
         return;
     }
     settings.setValue("task_bin", m_task_bin);
-    settings.setValue("task_data_path", m_task_data_path);
     settings.setValue("show_task_shell", m_show_task_shell);
     settings.setValue("hide_on_startup", m_hide_on_startup);
     settings.setValue("save_filter_on_exit", m_save_filter_on_exit);
@@ -161,7 +113,6 @@ bool ConfigManager::createNewConfigFile()
         return false;
     }
     settings.setValue("task_bin", s_default_task_bin);
-    settings.setValue("task_data_path", FindTaskDataFolder());
     settings.setValue("show_task_shell", false);
     settings.setValue("hide_on_startup", false);
     settings.setValue("save_filter_on_exit", false);
@@ -174,8 +125,6 @@ bool ConfigManager::fillOptionsFromConfigFile()
 {
     const QSettings settings(m_config_path, QSettings::IniFormat);
     m_task_bin = settings.value("task_bin", s_default_task_bin).toString();
-    m_task_data_path =
-        settings.value("task_data_path", FindTaskDataFolder()).toString();
     m_show_task_shell = settings.value("show_task_shell", false).toBool();
     m_hide_on_startup = settings.value("hide_on_startup", false).toBool();
     m_save_filter_on_exit =

--- a/src/configmanager.hpp
+++ b/src/configmanager.hpp
@@ -19,14 +19,6 @@ class ConfigManager : public QObject {
     const QString &getTaskBin() const { return m_task_bin; }
     void setTaskBin(const QString &v) { m_task_bin = v; }
 
-    QString getTaskDataPath() const { return m_task_data_path; }
-    void setTaskDataPath(const QString &v)
-    {
-        m_task_data_path = v;
-        if (!v.isEmpty() && v[v.size() - 1] != QDir::separator())
-            m_task_data_path += QDir::separator();
-    }
-
     bool getShowTaskShell() const { return m_show_task_shell; }
     void setShowTaskShell(bool v) { m_show_task_shell = v; }
 
@@ -56,9 +48,6 @@ class ConfigManager : public QObject {
 
     /// Path to task binary
     QString m_task_bin;
-
-    /// Path to taskwarrior data
-    QString m_task_data_path;
 
     /// Task shell will be shown in the main window
     bool m_show_task_shell;

--- a/src/exec_on_exit.hpp
+++ b/src/exec_on_exit.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <utility>
+
+/// @brief Execs callable when goes out of scope.
+template <typename taCallable>
+class exec_on_exit final {
+  public:
+    exec_on_exit() = delete;
+    exec_on_exit(const exec_on_exit &) = delete;
+    exec_on_exit(exec_on_exit &&) = default;
+    exec_on_exit &operator=(const exec_on_exit &) = delete;
+    exec_on_exit &operator=(exec_on_exit &&) = default;
+
+    explicit exec_on_exit(taCallable &&func) noexcept
+        : func(std::move(func))
+    {
+    }
+
+    ~exec_on_exit() { func(); }
+
+  private:
+    taCallable func;
+};

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -176,8 +176,11 @@ void MainWindow::initTasksTable()
 
     auto *model = new TasksModel(this);
     m_tasks_view->setModel(model);
-    m_tasks_view->setItemDelegateForColumn(2 /* description */,
-                                           new TaskDescriptionDelegate(this));
+
+    // All show hint, description column has additional logic too.
+    m_tasks_view->setItemDelegate(new TaskHintProviderDelegate(m_tasks_view));
+    m_tasks_view->setItemDelegateForColumn(
+        2 /* description */, new TaskDescriptionDelegate(m_tasks_view));
 
     connect(m_tasks_view->selectionModel(),
             &QItemSelectionModel::selectionChanged, this,

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -131,9 +131,8 @@ bool MainWindow::initTaskWatcher()
         m_task_watcher = nullptr;
         return false;
     }
-    connect(
-        m_task_watcher.get(), &TaskWatcher::dataChanged, this,
-        [&](const QString & /* filepath */) { updateTasks(/*force=*/true); });
+    connect(m_task_watcher.get(), &TaskWatcher::dataOnDiskWereChanged, this,
+            [&]() { updateTasks(/*force=*/true); });
     return true;
 }
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -84,7 +84,7 @@ class MainWindow : public QMainWindow {
     void onEditTaskAction();
     void showEditTaskDialog(const QModelIndex &);
 
-    void updateTasks(bool force = false);
+    void updateTasks();
     void updateTaskToolbar();
 
   signals:
@@ -129,7 +129,7 @@ class MainWindow : public QMainWindow {
     } const m_toolbar_actions;
 
     std::unique_ptr<Taskwarrior> m_task_provider;
-    std::unique_ptr<TaskWatcher> m_task_watcher;
+    TaskWatcher *m_task_watcher;
 };
 
 } // namespace ui

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -84,7 +84,7 @@ class MainWindow : public QMainWindow {
     void onEditTaskAction();
     void showEditTaskDialog(const QModelIndex &);
 
-    void updateTasks();
+    void updateTasksListTable();
     void updateTaskToolbar();
 
   signals:

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -9,6 +9,7 @@
 #include <QIcon>
 #include <QLabel>
 #include <QLineEdit>
+#include <QWidget>
 
 #include "configmanager.hpp"
 

--- a/src/settingsdialog.cpp
+++ b/src/settingsdialog.cpp
@@ -15,7 +15,6 @@
 SettingsDialog::SettingsDialog(QWidget *parent)
     : QDialog(parent)
     , m_task_bin_edit(new QLineEdit(this))
-    , m_task_data_path_edit(new QLineEdit(this))
     , m_hide_on_startup_cb(
           new QCheckBox(tr("Hide QTask window on startup"), this))
     , m_save_filter_on_exit(new QCheckBox(tr("Save task filter on exit"), this))
@@ -47,9 +46,6 @@ void SettingsDialog::initUI()
     auto *task_data_path_label = new QLabel(tr("Path to task data:"));
     main_layout->addWidget(task_data_path_label, 1, 0);
 
-    m_task_data_path_edit->setText(ConfigManager::config().getTaskDataPath());
-    main_layout->addWidget(m_task_data_path_edit, 1, 1);
-
     m_hide_on_startup_cb->setChecked(
         ConfigManager::config().getHideWindowOnStartup());
     main_layout->addWidget(m_hide_on_startup_cb, 2, 0, 1, 2);
@@ -67,11 +63,6 @@ void SettingsDialog::initUI()
 
 void SettingsDialog::applySettings()
 {
-    auto task_data_path = m_task_data_path_edit->text();
-    if (ConfigManager::config().getTaskDataPath() != task_data_path) {
-        ConfigManager::config().setTaskDataPath(task_data_path);
-    }
-
     auto task_bin = m_task_bin_edit->text();
     if (ConfigManager::config().getTaskBin() != task_bin) {
         ConfigManager::config().setTaskBin(task_bin);

--- a/src/settingsdialog.hpp
+++ b/src/settingsdialog.hpp
@@ -6,6 +6,7 @@
 #include <QDialog>
 #include <QDialogButtonBox>
 #include <QLineEdit>
+#include <QWidget>
 
 class SettingsDialog : public QDialog {
     Q_OBJECT

--- a/src/settingsdialog.hpp
+++ b/src/settingsdialog.hpp
@@ -22,7 +22,6 @@ class SettingsDialog : public QDialog {
     void applySettings();
 
     QLineEdit *const m_task_bin_edit;
-    QLineEdit *const m_task_data_path_edit;
     QCheckBox *const m_hide_on_startup_cb;
     QCheckBox *const m_save_filter_on_exit;
     QDialogButtonBox *const m_buttons;

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -361,7 +361,13 @@ bool DetailedTaskInfo::execReadExisting(const TaskWarriorExecutor &executor)
         });
     // After reading those are "not modified".
     SetPropertiesNotChanged(true, TASK_PROPERTIES_LIST);
+    dataState = ReadAs::FullRead;
     return true;
+}
+
+bool DetailedTaskInfo::isFullRead() const
+{
+    return dataState == ReadAs::FullRead;
 }
 
 BatchTasksManager::BatchTasksManager(const QList<DetailedTaskInfo> &tasks)

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -697,8 +697,7 @@ RecurringTaskTemplate::readAll(const TaskWarriorExecutor &executor)
     return out_tasks;
 }
 
-std::optional<TaskWarriorDbState>
-TaskWarriorDbState::readCurrent(const TaskWarriorExecutor &executor)
+TaskWarriorDbState::Optional TaskWarriorDbState::readCurrent(const TaskWarriorExecutor &executor)
 {
     static const QStringList cmd = { "stat" };
     const auto exec_res = executor.execTaskProgramWithDefaults(cmd);
@@ -726,6 +725,6 @@ TaskWarriorDbState::readCurrent(const TaskWarriorExecutor &executor)
         return std::nullopt;
     }
     TaskWarriorDbState res;
-    res.fields = std::move(fields);
+    res.fields = fields;
     return res;
 }

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -73,7 +73,7 @@ class DetailedTaskInfo {
     DetailedTaskInfo();
 
   private:
-    enum class ReadAs {
+    enum class ReadAs : std::uint8_t {
         ParticularRead,
         FullRead,
     };
@@ -172,6 +172,7 @@ struct RecurringTaskTemplate {
 /// if we must reload data from taskwarrior.
 class TaskWarriorDbState {
   public:
+    using Optional = std::optional<TaskWarriorDbState>;
     struct DataFields {
         ulong fieldTotal{ 0u };
         ulong fieldUndo{ 0u };
@@ -200,8 +201,7 @@ class TaskWarriorDbState {
     /// @note We select only fields we think can help us to detect modifications
     /// when we should update our GUI.
     [[nodiscard]]
-    static std::optional<TaskWarriorDbState>
-    readCurrent(const TaskWarriorExecutor &executor);
+    static Optional readCurrent(const TaskWarriorExecutor &executor);
 
   private:
     DataFields fields;

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -60,6 +60,10 @@ class DetailedTaskInfo {
     /// @returns true if object was properly read.
     bool execReadExisting(const TaskWarriorExecutor &executor);
 
+    /// @returns true if this object has all possible data read from `task`.
+    [[nodiscard]]
+    bool isFullRead() const;
+
   public:
     /// @brief Constructs object with defaults, except given @p task_id set.
     explicit DetailedTaskInfo(QString task_id);
@@ -69,6 +73,13 @@ class DetailedTaskInfo {
     DetailedTaskInfo();
 
   private:
+    enum class ReadAs {
+        ParticularRead,
+        FullRead,
+    };
+
+    ReadAs dataState{ ReadAs::ParticularRead };
+
     [[nodiscard]]
     QStringList getAddModifyCmdArgsFieldsRepresentation() const;
 };

--- a/src/taskdescriptiondelegate.cpp
+++ b/src/taskdescriptiondelegate.cpp
@@ -11,7 +11,7 @@
 // but without markdown it will draw multiline string outside limits.
 
 TaskDescriptionDelegate::TaskDescriptionDelegate(QObject *parent)
-    : QStyledItemDelegate(parent)
+    : TaskHintProviderDelegate(parent)
 {
 }
 

--- a/src/taskdescriptiondelegate.hpp
+++ b/src/taskdescriptiondelegate.hpp
@@ -1,21 +1,26 @@
 #ifndef TASKDESCRIPTIONDELEGATE_HPP
 #define TASKDESCRIPTIONDELEGATE_HPP
 
+#include <QObject>
 #include <QPainter>
 #include <QString>
+#include <QStyleOptionViewItem>
 #include <QStyledItemDelegate>
 
-class TaskDescriptionDelegate : public QStyledItemDelegate {
+#include "taskhintproviderdelegate.hpp"
+
+class TaskDescriptionDelegate : public TaskHintProviderDelegate {
     Q_OBJECT
 
   public:
-    TaskDescriptionDelegate(QObject *parent = nullptr);
+    explicit TaskDescriptionDelegate(QObject *parent = nullptr);
 
     QString anchorAt(const QString &markdown, const QPoint &point) const;
 
   protected:
     void paint(QPainter *painter, const QStyleOptionViewItem &option,
                const QModelIndex &index) const override;
+    [[nodiscard]]
     QSize sizeHint(const QStyleOptionViewItem &option,
                    const QModelIndex &index) const override;
 };

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -1,0 +1,239 @@
+#include "taskhintproviderdelegate.hpp"
+#include "async_task_loader.hpp"
+#include "task.hpp"
+#include "tasksmodel.hpp"
+
+#include <QAbstractItemView>
+#include <QHelpEvent>
+#include <QModelIndex>
+#include <QObject>
+#include <QStyleOptionViewItem>
+#include <QStyledItemDelegate>
+#include <QTimer>
+#include <QToolTip>
+#include <QVariant>
+#include <QWidget>
+
+#include <mutex>
+
+namespace
+{
+QString getLoadingTooltip(const QString &footer)
+{
+    QString tooltip = QObject::tr("Loading...");
+    if (!footer.isEmpty()) {
+        tooltip += "\n";
+        tooltip += footer;
+    }
+    return tooltip;
+}
+
+QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
+{
+    if (!task.isFullRead()) {
+        // Backup plan, possibly async failed to load data.
+        return getLoadingTooltip(footer);
+    }
+    QString html = "<style>"
+                   "h3 { margin: 0 0 3px 0; color: #34495e; }"
+                   "p { margin: 2px 0; }"
+                   ".info-block { border-top: 1px solid #eee; padding-top: "
+                   "5px; margin-top: 5px; }"
+                   ".priority-high { color: red; font-weight: bold; }"
+                   ".date-due { color: #8e44ad; font-weight: bold; }"
+                   ".tag-list { padding-left: 20px; margin: 0; }"
+                   ".date-overdue { color: red; font-weight: bold; }"
+                   ".date-approaching { color: orange; font-weight: bold; }"
+                   ".date-normal { color: #555; }"
+                   "</style>";
+
+    const QDateTime now = QDateTime::currentDateTime();
+    const qint64 oneDayMs = 24 * 60 * 60 * 1000;
+    auto getDateCssClass = [&](const QDateTime &dt) -> QString {
+        qint64 diffMs = now.msecsTo(dt);
+
+        if (dt < now) {
+            return "date-overdue";
+        } else if (diffMs < oneDayMs) {
+            return "date-approaching";
+        }
+        return "date-normal";
+    };
+
+    const QString &descriptionStr = task.description.get();
+    if (!descriptionStr.isEmpty()) {
+        html += QString("<h3>%1</h3>").arg(descriptionStr.toHtmlEscaped());
+    } else {
+        html += QString("<p style='color:#aaa;'>ID: %1</p>").arg(task.task_id);
+    }
+
+    // ------------------------------------------------
+    // PROJECT
+    // ------------------------------------------------
+    html += "<div class='info-block'>";
+
+    // Project (QString)
+    if (!task.project.get().isEmpty()) {
+        html += QString("<p><b>Project:</b> <i>%1</i></p>")
+                    .arg(task.project.get().toHtmlEscaped());
+    }
+
+    html += "</div>";
+
+    // ------------------------------------------------
+    // DATES (std::optional<QDateTime>)
+    // ------------------------------------------------
+    const auto &optionalDue = task.due.get();
+    const auto &optionalSched = task.sched.get();
+    const auto &optionalWait = task.wait.get();
+
+    const bool hasDates = optionalDue.has_value() ||
+                          optionalSched.has_value() || optionalWait.has_value();
+    if (hasDates) {
+        html += "<div class='info-block'><h3>Dates</h3>";
+
+        // DUE DATE
+        if (optionalDue.has_value()) {
+            const QDateTime &dt = optionalDue.value();
+            QString dateStr = dt.toString();
+            QString cssClass = getDateCssClass(dt);
+
+            html +=
+                QString(
+                    "<p class='date-due'><span class='%1'>Due: %2</span></p>")
+                    .arg(cssClass)
+                    .arg(dateStr);
+        }
+
+        // SCHED DATE
+        if (optionalSched.has_value()) {
+            const QDateTime &dt = optionalSched.value();
+            QString dateStr = dt.toString();
+            QString cssClass = getDateCssClass(dt);
+
+            html += QString("<p><span class='%1'>Scheduled: %2</span></p>")
+                        .arg(cssClass)
+                        .arg(dateStr);
+        }
+
+        // WAIT DATE
+        if (optionalWait.has_value()) {
+            const QDateTime &dt = optionalWait.value();
+            QString dateStr = dt.toString();
+            QString cssClass = getDateCssClass(dt);
+
+            html += QString("<p><span class='%1'>Wait until: %2</span></p>")
+                        .arg(cssClass)
+                        .arg(dateStr);
+        }
+
+        html += "</div>";
+    }
+
+    // ------------------------------------------------
+    // TAGS (QStringList)
+    // ------------------------------------------------
+    const QStringList &tagsList = task.tags.get();
+    if (!tagsList.isEmpty()) {
+        html += "<div class='info-block'><h3>Tags</h3><ul class='tag-list'>";
+        for (const QString &tag : tagsList) {
+            html += QString("<li>%1</li>").arg(tag.toHtmlEscaped());
+        }
+        html += "</ul></div>";
+    }
+
+    // ------------------------------------------------
+    // FOOTER
+    // ------------------------------------------------
+    if (!footer.isEmpty()) {
+        html += QString("<div class='info-block' style='color:#888;'>%1</div>")
+                    .arg(footer.toHtmlEscaped());
+    }
+
+    return html;
+}
+
+} // namespace
+
+TaskHintProviderDelegate::TaskHintProviderDelegate(QObject *parent)
+    : QStyledItemDelegate{ parent }
+    , m_task_loader(AsyncTaskLoader::create(this))
+{
+    static std::once_flag metaTypeRegistrationFlag;
+    std::call_once(metaTypeRegistrationFlag, []() {
+        qRegisterMetaType<TaskLoaderParameters>("TaskLoaderParameters");
+    });
+
+    connect(m_task_loader, &AsyncTaskLoader::latestLoadingFinished, this,
+            [this](const QVariant &varParams, [[maybe_unused]] int requestId,
+                   const DetailedTaskInfo &fullTask) {
+                if (!varParams.canConvert<TaskLoaderParameters>()) {
+                    return;
+                }
+                auto params = varParams.value<TaskLoaderParameters>();
+                if (params.view) {
+                    if (params.index.isValid()) {
+                        params.view->model()->setData(
+                            params.index, QVariant::fromValue(fullTask),
+                            TasksModel::TaskUpdateRole);
+                    }
+                    // We got good response, cancel "Loading" timer to avoid
+                    // blinking.
+                    m_pendingLoadingRequestId.store(
+                        AsyncTaskLoader::kInvalidRequestId);
+                    QToolTip::showText(
+                        params.cursor_pos,
+                        generateTooltip(fullTask, getToolTipFooter()),
+                        params.view);
+                }
+            });
+}
+
+bool TaskHintProviderDelegate::helpEvent(QHelpEvent *event,
+                                         QAbstractItemView *view,
+                                         const QStyleOptionViewItem &option,
+                                         const QModelIndex &index)
+{
+    if (event->type() != QEvent::ToolTip || !index.isValid()) {
+        return QStyledItemDelegate::helpEvent(event, view, option, index);
+    }
+    const auto variantTask =
+        index.model()->data(index, TasksModel::TaskReadRole);
+
+    if (!variantTask.isValid()) {
+        QToolTip::hideText();
+        return true;
+    }
+    const auto task = variantTask.value<DetailedTaskInfo>();
+
+    if (!task.isFullRead()) {
+        const TaskLoaderParameters params{ index, view, event->globalPos() };
+        const auto currentRequestId =
+            m_task_loader->startTaskLoad(params, task);
+        // It is safe, because lambda which will write it is in the same GUI
+        // thread.
+        m_pendingLoadingRequestId.store(currentRequestId);
+        QTimer::singleShot(400, this, [this, params, currentRequestId]() {
+            // If it is the same value as before singleShot, then async response
+            // didn't reset it yet.
+            if (m_pendingLoadingRequestId.load() == currentRequestId) {
+                m_pendingLoadingRequestId.store(
+                    AsyncTaskLoader::kInvalidRequestId);
+                if (params.view) {
+                    QToolTip::showText(params.cursor_pos,
+                                       getLoadingTooltip(getToolTipFooter()),
+                                       params.view);
+                }
+            }
+        });
+    }
+
+    return true;
+}
+
+const QString &TaskHintProviderDelegate::getToolTipFooter() const
+{
+    static const QString hint(
+        tr("Right-click in project col to add to filters."));
+    return hint;
+}

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -203,9 +203,13 @@ bool TaskHintProviderDelegate::helpEvent(QHelpEvent *event,
         return true;
     }
     const auto task = variantTask.value<DetailedTaskInfo>();
+    const TaskLoaderParameters params{ index, view, event->globalPos() };
 
-    if (!task.isFullRead()) {
-        const TaskLoaderParameters params{ index, view, event->globalPos() };
+    if (task.isFullRead()) {
+        QToolTip::showText(params.cursor_pos,
+                           generateTooltip(task, getToolTipFooter()),
+                           params.view);
+    } else {
         const auto currentRequestId =
             m_task_loader->startTaskLoad(params, task);
         // It is safe, because lambda which will write it is in the same GUI

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -7,6 +7,7 @@
 #include <QHelpEvent>
 #include <QModelIndex>
 #include <QObject>
+#include <QStringList>
 #include <QStyleOptionViewItem>
 #include <QStyledItemDelegate>
 #include <QTimer>
@@ -50,7 +51,7 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
     const QDateTime now = QDateTime::currentDateTime();
     const qint64 oneDayMs = 24 * 60 * 60 * 1000;
     auto getDateCssClass = [&](const QDateTime &dt) -> QString {
-        qint64 diffMs = now.msecsTo(dt);
+        const qint64 diffMs = now.msecsTo(dt);
 
         if (dt < now) {
             return "date-overdue";
@@ -95,36 +96,33 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
         // DUE DATE
         if (optionalDue.has_value()) {
             const QDateTime &dt = optionalDue.value();
-            QString dateStr = dt.toString();
-            QString cssClass = getDateCssClass(dt);
+            const QString dateStr = dt.toString();
+            const QString cssClass = getDateCssClass(dt);
 
             html +=
                 QString(
                     "<p class='date-due'><span class='%1'>Due: %2</span></p>")
-                    .arg(cssClass)
-                    .arg(dateStr);
+                    .arg(cssClass, dateStr);
         }
 
         // SCHED DATE
         if (optionalSched.has_value()) {
             const QDateTime &dt = optionalSched.value();
-            QString dateStr = dt.toString();
-            QString cssClass = getDateCssClass(dt);
+            const QString dateStr = dt.toString();
+            const QString cssClass = getDateCssClass(dt);
 
             html += QString("<p><span class='%1'>Scheduled: %2</span></p>")
-                        .arg(cssClass)
-                        .arg(dateStr);
+                        .arg(cssClass, dateStr);
         }
 
         // WAIT DATE
         if (optionalWait.has_value()) {
             const QDateTime &dt = optionalWait.value();
-            QString dateStr = dt.toString();
-            QString cssClass = getDateCssClass(dt);
+            const QString dateStr = dt.toString();
+            const QString cssClass = getDateCssClass(dt);
 
             html += QString("<p><span class='%1'>Wait until: %2</span></p>")
-                        .arg(cssClass)
-                        .arg(dateStr);
+                        .arg(cssClass, dateStr);
         }
 
         html += "</div>";

--- a/src/taskhintproviderdelegate.hpp
+++ b/src/taskhintproviderdelegate.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <QAbstractItemView>
+#include <QHelpEvent>
+#include <QModelIndex>
+#include <QObject>
+#include <QPointer>
+#include <QStyleOptionViewItem>
+#include <QStyledItemDelegate>
+#include <QWidget>
+
+#include <atomic>
+
+#include "async_task_loader.hpp"
+
+class TaskHintProviderDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+  public:
+    struct TaskLoaderParameters {
+        QPersistentModelIndex index;
+        QPointer<QAbstractItemView> view;
+        QPoint cursor_pos;
+    };
+
+    explicit TaskHintProviderDelegate(QObject *parent = nullptr);
+
+    bool helpEvent(QHelpEvent *event, QAbstractItemView *view,
+                   const QStyleOptionViewItem &option,
+                   const QModelIndex &index) override;
+
+  protected:
+    [[nodiscard]]
+    virtual const QString &getToolTipFooter() const;
+
+  private:
+    AsyncTaskLoader *m_task_loader;
+    // This is used to cancel timer.
+    std::atomic<AsyncTaskLoader::RequestId> m_pendingLoadingRequestId{
+        AsyncTaskLoader::kInvalidRequestId
+    };
+};
+Q_DECLARE_METATYPE(TaskHintProviderDelegate::TaskLoaderParameters)

--- a/src/taskhintproviderdelegate.hpp
+++ b/src/taskhintproviderdelegate.hpp
@@ -13,6 +13,16 @@
 
 #include "async_task_loader.hpp"
 
+/// @brief This delegate provides detailed tooltip on row.
+///
+/// @note We implement custom tooltip handling (using QStyledItemDelegate)
+/// instead of relying on the model's Qt::ToolTipRole.
+///
+/// Rationale: When switching between the "loading" tooltip state and the "full
+/// details" state, using the model handler would require the user to move the
+/// mouse to trigger the new content. The delegate allows us to dynamically
+/// **update the tooltip content in place** without requiring any mouse
+/// movement, resulting in a much smoother and better user experience.
 class TaskHintProviderDelegate : public QStyledItemDelegate {
     Q_OBJECT
   public:

--- a/src/tasksmodel.cpp
+++ b/src/tasksmodel.cpp
@@ -11,8 +11,10 @@
 #include <QModelIndex>
 #include <QObject>
 #include <QVariant>
+#include <QtCore/Qt>
 #include <qlogging.h>
 #include <qnamespace.h>
+#include <qtmetamacros.h>
 
 #include "task.hpp"
 
@@ -31,8 +33,13 @@ int TasksModel::columnCount(const QModelIndex & /*parent*/) const { return 3; }
 
 QVariant TasksModel::data(const QModelIndex &index, int role) const
 {
-    if (role == Qt::DisplayRole) {
-        const DetailedTaskInfo task = m_tasks.at(index.row());
+    if (!index.isValid()) {
+        return {};
+    }
+    const auto &task = m_tasks.at(index.row());
+
+    switch (role) {
+    case Qt::DisplayRole: {
         switch (index.column()) {
         case 0:
             return task.task_id;
@@ -44,53 +51,78 @@ QVariant TasksModel::data(const QModelIndex &index, int role) const
             qDebug() << "Unexpected case in TasksModel::data";
             break;
         }
-    } else if (role == Qt::DecorationRole) {
+        break;
+    }
+    case Qt::DecorationRole:
         if (index.column() == 0) {
             return (m_tasks.at(index.row()).active)
                        ? QIcon(":/icons/active.svg")
                        : QVariant{};
         }
-    } else if (role == Qt::BackgroundRole) {
+        break;
+    case Qt::BackgroundRole:
         return QVariant(QBrush(rowColor(index.row())));
+    case TaskReadRole:
+        return QVariant::fromValue(task);
+    default:
+        break;
     }
 
     return {};
 }
 
-bool TasksModel::setData(const QModelIndex &idx, const QVariant & /*value*/,
+bool TasksModel::setData(const QModelIndex &idx, const QVariant &value,
                          int role)
 {
     if (!idx.isValid()) {
         return false;
     }
+    const int row = idx.row();
 
-    if (role == Qt::EditRole) {
-        const int row = idx.row();
-        qDebug() << "Requested edit " << row;
+    switch (role) {
+    case Qt::EditRole:
+        qDebug()
+            << "Requested edit which is not supported / implemented on row [ "
+            << row << " ].";
+        break;
+    case TaskUpdateRole:
+        if (value.canConvert<DetailedTaskInfo>()) {
+            auto updatedTask = value.value<DetailedTaskInfo>();
+            m_tasks[row] = updatedTask;
+            const auto start = index(row, 0);
+            const auto end = index(row, columnCount() - 1);
+            emit dataChanged(start, end,
+                             { Qt::DisplayRole, Qt::BackgroundRole });
+            return true;
+        }
+        break;
+    default:
+        break;
     }
-
-    return true;
+    // Data was NOT changed - result is false. Point.
+    return false;
 }
 
 QVariant TasksModel::headerData(int section, Qt::Orientation orientation,
                                 int role) const
 {
-    if (role != Qt::DisplayRole) {
-        return {};
-    }
-
-    if (orientation == Qt::Horizontal) {
-        switch (section) {
-        case 0:
-            return tr("id");
-        case 1:
-            return tr("Project");
-        case 2:
-            return tr("Description");
-        default:
-            qDebug() << "Unexpected case in TasksModel::headerData";
-            break;
+    switch (role) {
+    case Qt::DisplayRole:
+        if (orientation == Qt::Horizontal) {
+            switch (section) {
+            case 0:
+                return tr("id");
+            case 1:
+                return tr("Project");
+            case 2:
+                return tr("Description");
+            default:
+                qDebug() << "Unexpected case in TasksModel::headerData";
+                break;
+            }
         }
+    default:
+        break;
     }
 
     return {};

--- a/src/tasksmodel.hpp
+++ b/src/tasksmodel.hpp
@@ -35,12 +35,17 @@ class TasksModel : public QAbstractTableModel {
     QVariant headerData(int section, Qt::Orientation,
                         int role = Qt::DisplayRole) const override;
 
-    void setTasks(QList<DetailedTaskInfo>);
+    void setTasks(QList<DetailedTaskInfo>,
+                  const QStringList &currentlySelectedTaskIds);
 
     [[nodiscard]]
     QVariant getTask(const QModelIndex &) const;
 
     QColor rowColor(int row) const;
+  signals:
+    // View can listen this signal if it wants to restore selection after model
+    // reset.
+    void selectIndices(const QModelIndexList &);
 
   private:
     QList<DetailedTaskInfo> m_tasks;

--- a/src/tasksmodel.hpp
+++ b/src/tasksmodel.hpp
@@ -6,25 +6,38 @@
 #include <QList>
 #include <QModelIndex>
 #include <QVariant>
+#include <QtCore/Qt>
 
 #include "task.hpp"
 
 class TasksModel : public QAbstractTableModel {
     Q_OBJECT
   public:
-    TasksModel(QObject *parent = nullptr);
-    ~TasksModel() = default;
+    static constexpr auto TaskUpdateRole = Qt::UserRole + 1;
+    static constexpr auto TaskReadRole = Qt::UserRole + 2;
 
+    explicit TasksModel(QObject *parent = nullptr);
+
+    [[nodiscard]]
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    [[nodiscard]]
     int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    [[nodiscard]]
     QVariant data(const QModelIndex &index,
                   int role = Qt::DisplayRole) const override;
-    bool setData(const QModelIndex &, const QVariant &,
+
+    bool setData(const QModelIndex &, const QVariant &value,
                  int role = Qt::EditRole) override;
+
+    [[nodiscard]]
     QVariant headerData(int section, Qt::Orientation,
                         int role = Qt::DisplayRole) const override;
 
     void setTasks(QList<DetailedTaskInfo>);
+
+    [[nodiscard]]
     QVariant getTask(const QModelIndex &) const;
 
     QColor rowColor(int row) const;

--- a/src/taskwarriorexecutor.cpp
+++ b/src/taskwarriorexecutor.cpp
@@ -76,6 +76,12 @@ TaskWarriorExecutor::TaskWarriorExecutor(QString full_path_to_binary)
     throw_if_true(!execTaskProgram({ "rc.gc=on" }));
 }
 
+TaskWarriorExecutor::TaskWarriorExecutor(QString full_path_to_binary,
+                                         TSkipBinaryValidation)
+    : m_full_path_to_binary(std::move(full_path_to_binary))
+{
+}
+
 const QString &TaskWarriorExecutor::getTaskVersion() const
 {
     return m_task_version;

--- a/src/taskwarriorexecutor.hpp
+++ b/src/taskwarriorexecutor.hpp
@@ -8,6 +8,8 @@
 /// @brief This class provides generic interface to launch `task`command.
 class TaskWarriorExecutor {
   public:
+    struct TSkipBinaryValidation {};
+
     /// @brief Error code and error message of executing the program.
     struct TExecError {
         int code;
@@ -59,6 +61,13 @@ class TaskWarriorExecutor {
     /// @param full_path_to_binary should point to binary `task`.
     /// @throws if given path does not point to proper `task` command.
     explicit TaskWarriorExecutor(QString full_path_to_binary);
+
+    /// @brief Constructs object with given path.
+    /// @param full_path_to_binary should point to binary `task`.
+    /// @note this version avoids all checks, including version check. This
+    /// should be used for performance reasons.
+    explicit TaskWarriorExecutor(QString full_path_to_binary,
+                                 TSkipBinaryValidation);
 
     /// @brief Executes configured task with defaults required parameters and
     /// @returns TExecResult.

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -46,8 +46,8 @@ TaskWatcher::TaskWatcher(QObject *parent)
             if (opt && opt->isDifferent(m_latestDbState)) {
                 m_latestDbState = *opt;
                 m_check_for_changes_timer.start();
-                emit dataOnDiskWereChanged();
             }
+            emit dataOnDiskWereChanged();
         },
         Qt::QueuedConnection);
 }

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -85,8 +85,9 @@ void TaskWatcher::checkNow()
         [](const auto &pathToBinary) -> TaskWarriorDbState::Optional {
             try {
                 // This is non-GUI thread.
-                return TaskWarriorDbState::readCurrent(
-                    TaskWarriorExecutor(pathToBinary));
+                return TaskWarriorDbState::readCurrent(TaskWarriorExecutor(
+                    pathToBinary,
+                    TaskWarriorExecutor::TSkipBinaryValidation{}));
             } catch (...) { // NOLINT
             }
             return std::nullopt;

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -60,9 +60,9 @@ TaskWatcher::TaskWatcher(QObject *parent)
             auto opt = m_state_reader->future().result();
             if (opt && opt->isDifferent(m_latestDbState)) {
                 m_latestDbState = *opt;
-                m_check_for_changes_timer.start();
+                emit dataOnDiskWereChanged();
             }
-            emit dataOnDiskWereChanged();
+            m_check_for_changes_timer.start();
         },
         Qt::QueuedConnection);
 }

--- a/src/taskwatcher.hpp
+++ b/src/taskwatcher.hpp
@@ -4,15 +4,17 @@
 #include <QFileSystemWatcher>
 #include <QObject>
 #include <QString>
+#include <QTimer>
 
 #include <memory>
 
+/// @brief This object watches changes of the TaskWarrior specifiec data files
+/// on filesystem and triggers full re-read if those were changed.
 class TaskWatcher : public QObject {
     Q_OBJECT
 
   public:
     explicit TaskWatcher(QObject *parent = nullptr);
-    ~TaskWatcher() override;
 
     bool setup(const QString &task_data_path);
     [[nodiscard]] bool isActive() const
@@ -21,10 +23,12 @@ class TaskWatcher : public QObject {
     }
 
   signals:
-    void dataChanged(const QString &);
+    void dataOnDiskWereChanged();
 
   private:
     std::unique_ptr<QFileSystemWatcher> m_task_data_watcher{ nullptr };
+    // Do not react too often.
+    QTimer m_debounce_timer;
 };
 
 #endif // TASKWATCHER_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TASK_DEPENDENT_FILES
 # Reverse, those files are part of main binary, and should be linked if task tests remain active.
 set(TASK_DEPENDENT_FILES_TO_LINK
     "../src/taskwarriorexecutor.cpp"
+    "../src/task.cpp"
 )
 
 #Find taskwarrior `task` binary.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,33 @@ file(GLOB_RECURSE TESTS_LIST
      ${CMAKE_CURRENT_LIST_DIR}/*.hpp
      ${CMAKE_CURRENT_LIST_DIR}/*.cpp
     )
+
+# List of tests which will require `test` binary present. Those will be dropped,
+# if one was not installed.
+set(TASK_DEPENDENT_FILES
+    "taskwarriorexecutor_test.cpp"
+)
+
+# Reverse, those files are part of main binary, and should be linked if task tests remain active.
+set(TASK_DEPENDENT_FILES_TO_LINK
+    "../src/taskwarriorexecutor.cpp"
+)
+
+#Find taskwarrior `task` binary.
+find_program(TASK_EXECUTABLE NAMES task)
+if (NOT TASK_EXECUTABLE)
+    message(STATUS "Binary 'task' was not found. REMOVING some tests which would require it.")
+
+    # Important: GLOB_RECURSE returns full paths, so we have to use it here too to exclude.
+    foreach(FILENAME_TO_EXCLUDE IN LISTS TASK_DEPENDENT_FILES)
+        set(FULL_PATH_TO_EXCLUDE "${CMAKE_CURRENT_LIST_DIR}/${FILENAME_TO_EXCLUDE}")
+        list(REMOVE_ITEM TESTS_LIST "${FULL_PATH_TO_EXCLUDE}")
+        message(STATUS " --> Excluded: ${FILENAME_TO_EXCLUDE}")
+    endforeach()
+else()
+    message(STATUS "Binary 'task' found: ${TASK_EXECUTABLE}. Using all possible tests.")
+endif()
+
 list(LENGTH TESTS_LIST TESTS_LIST_FILES_COUNT)
 if (TESTS_LIST_FILES_COUNT GREATER 0)
     find_package(GTest REQUIRED)
@@ -31,12 +58,23 @@ if (TESTS_LIST_FILES_COUNT GREATER 0)
 
     message(STATUS "Found Qt version for tests: ${QT_VERSION}.")
 
-
     source_group("tests" FILES ${TESTS_LIST})
     add_executable(qtask_tests
                    ${TESTS_LIST}
                    ../src/qtutil.cpp
     )
+
+    if (TASK_EXECUTABLE)
+        target_compile_definitions(qtask_tests
+            PRIVATE
+            TASK_EXECUTABLE_PATH="${TASK_EXECUTABLE}"
+        )
+        target_sources(qtask_tests
+            PRIVATE
+            ${TASK_DEPENDENT_FILES_TO_LINK}
+        )
+    endif()
+
     target_link_libraries(qtask_tests PRIVATE
                         gtest
                         gmock

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(qtask_tests CXX)
 

--- a/tests/qtutil_test.cpp
+++ b/tests/qtutil_test.cpp
@@ -1,3 +1,4 @@
+#include "exec_on_exit.hpp"
 #include "qtutil.hpp"
 
 #include <gtest/gtest.h>
@@ -11,6 +12,17 @@ TEST_F(QtUtilTest, IsIntegerWorks)
     EXPECT_TRUE(isInteger("232345871"));
     EXPECT_FALSE(isInteger("23SKF2345871"));
     EXPECT_FALSE(isInteger("SDDDDDDD"));
+}
+
+TEST_F(QtUtilTest, ExecOnExitWorks)
+{
+    int val = 0;
+    {
+        EXPECT_EQ(val, 0);
+        const exec_on_exit totest([&val]() { val = 1; });
+        EXPECT_EQ(val, 0);
+    }
+    EXPECT_EQ(val, 1);
 }
 
 } // namespace Test

--- a/tests/taskwarriorexecutor_test.cpp
+++ b/tests/taskwarriorexecutor_test.cpp
@@ -1,3 +1,4 @@
+#include "task.hpp"
 #include "taskwarriorexecutor.hpp"
 
 #include <QString>
@@ -26,6 +27,20 @@ TEST_F(TaskWarriorExecutorTest, WorksIfFound)
 {
     const TaskWarriorExecutor executor(kTaskCommand);
     EXPECT_FALSE(executor.getTaskVersion().isEmpty());
+}
+
+TEST_F(TaskWarriorExecutorTest, TaskWarriorDbStateUpdates)
+{
+    const TaskWarriorExecutor executor(kTaskCommand);
+    EXPECT_FALSE(executor.getTaskVersion().isEmpty());
+
+    const TaskWarriorDbState def;
+    const auto read = TaskWarriorDbState::readCurrent(executor);
+
+    ASSERT_TRUE(read);
+    EXPECT_TRUE(read->isDifferent(def)) // NOLINT
+        << "Note, this test may fail IF you have fresh installed TaskWarrior "
+           "in the system without tasks on it.";
 }
 
 } // namespace Test

--- a/tests/taskwarriorexecutor_test.cpp
+++ b/tests/taskwarriorexecutor_test.cpp
@@ -1,0 +1,31 @@
+#include "taskwarriorexecutor.hpp"
+
+#include <QString>
+
+#include <gtest/gtest.h>
+#include <stdexcept>
+
+namespace
+{
+// Defined by CMake.
+const QString kTaskCommand = TASK_EXECUTABLE_PATH;
+
+} // namespace
+
+namespace Test
+{
+using TaskWarriorExecutorTest = ::testing::Test;
+
+TEST_F(TaskWarriorExecutorTest, ThrowsIfNotFound)
+{
+    static const auto alloc = []() { return TaskWarriorExecutor("abrvalg!"); };
+    EXPECT_THROW(alloc(), std::runtime_error);
+}
+
+TEST_F(TaskWarriorExecutorTest, WorksIfFound)
+{
+    const TaskWarriorExecutor executor(kTaskCommand);
+    EXPECT_FALSE(executor.getTaskVersion().isEmpty());
+}
+
+} // namespace Test


### PR DESCRIPTION
## New

It shows tool-tip when mouse over:
<img width="550" height="223" alt="image" src="https://github.com/user-attachments/assets/374aa6c2-6eb5-494c-9e1c-5285f4647069" />

## Details

Added delegate for rows `TaskHintProviderDelegate` which handles tool-tip asynchronously.

Completely reworked `TaskWatcher`, now it does async queries to `task stat` once per N seconds and uses output to decide if we need to update data because reading information for tool-tip was triggering old `QFileWatcher` and it was infinite loop through FS.

Completely removed all configuration of "task warrior data folder" as it is not needed now.

Now any try to update data from UI components will go through `TaskWatcher`.

Now we try to keep selection as much as possible on UI update. This requires additional migration to use `JSON` instead parsing console output.

Updated minimal `cmake` version to 3.18 instead 9 years old 3.8.

Updated `CMakeLists.txt`.

Add more new tests.
