### PR TITLE
Fix reload when filter by tags changed

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -661,6 +661,8 @@ void MainWindow::onApplyFilter()
 {
     if (!m_task_provider->applyFilter(m_task_filter->getTags())) {
         m_task_filter->popTag();
+    } else {
+        m_task_watcher->enforceUpdate();
     }
     // if (!m_task_provider->applyFilter(m_task_filter->getTags()))
     //     m_task_filter->clearTags();

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <optional>
 #include <stdexcept>
 #include <unordered_map>
@@ -697,7 +698,8 @@ RecurringTaskTemplate::readAll(const TaskWarriorExecutor &executor)
     return out_tasks;
 }
 
-TaskWarriorDbState::Optional TaskWarriorDbState::readCurrent(const TaskWarriorExecutor &executor)
+TaskWarriorDbState::Optional
+TaskWarriorDbState::readCurrent(const TaskWarriorExecutor &executor)
 {
     static const QStringList cmd = { "stat" };
     const auto exec_res = executor.execTaskProgramWithDefaults(cmd);
@@ -724,7 +726,14 @@ TaskWarriorDbState::Optional TaskWarriorDbState::readCurrent(const TaskWarriorEx
     if (!setters.areAllFieldsParsed()) {
         return std::nullopt;
     }
-    TaskWarriorDbState res;
-    res.fields = fields;
-    return res;
+    return TaskWarriorDbState(fields);
+}
+
+TaskWarriorDbState TaskWarriorDbState::invalidState()
+{
+    static const TaskWarriorDbState::DataFields invalid_state{
+        std::numeric_limits<uint>::max(), std::numeric_limits<uint>::max(),
+        std::numeric_limits<uint>::max()
+    };
+    return TaskWarriorDbState(invalid_state);
 }

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -191,6 +191,8 @@ class TaskWarriorDbState {
             return Tie(*this) == Tie(other);
         }
     };
+
+    TaskWarriorDbState() = default;
     bool isDifferent(const TaskWarriorDbState &other) const
     {
         return this->fields != other.fields;
@@ -203,7 +205,14 @@ class TaskWarriorDbState {
     [[nodiscard]]
     static Optional readCurrent(const TaskWarriorExecutor &executor);
 
+    /// @returns state which cannot be valid.
+    static TaskWarriorDbState invalidState();
+
   private:
+    explicit TaskWarriorDbState(TaskWarriorDbState::DataFields fields)
+        : fields(fields)
+    {
+    }
     DataFields fields;
 };
 

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -95,3 +95,8 @@ void TaskWatcher::checkNow()
         ConfigManager::config().getTaskBin());
     m_state_reader->setFuture(future);
 }
+
+void TaskWatcher::enforceUpdate()
+{
+    m_latestDbState = TaskWarriorDbState::invalidState();
+}

--- a/src/taskwatcher.hpp
+++ b/src/taskwatcher.hpp
@@ -26,6 +26,9 @@ class TaskWatcher : public QObject {
   public slots:
     void checkNow();
 
+    /// @brief Next checkNow() will do update.
+    void enforceUpdate();
+
   private:
     QFutureWatcher<TaskWarriorDbState::Optional> *m_state_reader;
     QTimer m_check_for_changes_timer;


### PR DESCRIPTION
Fix newly introduced bug, adding tags was not reloading tasks list.
