### PR TITLE
Fixed wrapping of the description in table.

### DIFF
--- a/src/taskdescriptiondelegate.cpp
+++ b/src/taskdescriptiondelegate.cpp
@@ -2,32 +2,60 @@
 
 #include <QAbstractTextDocumentLayout>
 #include <QApplication>
+#include <QObject>
+#include <QSize>
+#include <QString>
+#include <QStyleOptionViewItem>
 #include <QStyledItemDelegate>
 #include <QTextDocument>
+#include <QtAssert>
+#include <QtVersionChecks>
 
+#include "taskhintproviderdelegate.hpp"
 #include "tasksmodel.hpp"
 
 // FIXME: this is sort of broken, for example it will not show \\ as markdown
 // but without markdown it will draw multiline string outside limits.
+namespace
+{
 
+void initDocument(QTextDocument &document, const QString &whole_text)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    document.setMarkdown(whole_text);
+#else
+    document.setPlainText(whole_text);
+#endif // QT_VERSION_CHECK
+}
+
+/// @returns true if elide is needed.
+bool initDocument(QTextDocument &document, const QStyleOptionViewItem &option,
+                  const QString &whole_text)
+{
+    initDocument(document, whole_text);
+    document.setTextWidth(option.rect.width());
+
+    const QFontMetrics fm(option.font);
+    const bool elide_needed = document.size().height() / fm.height() > 1.5f;
+
+    document.setPageSize(option.rect.size());
+
+    return elide_needed;
+}
+
+} // namespace
 TaskDescriptionDelegate::TaskDescriptionDelegate(QObject *parent)
     : TaskHintProviderDelegate(parent)
+    , document(new QTextDocument(this))
 {
 }
 
 QString TaskDescriptionDelegate::anchorAt(const QString &markdown,
                                           const QPoint &point) const
 {
-    QTextDocument doc;
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    doc.setMarkdown(markdown);
-#else
-    doc.setPlainText(markdown);
-#endif // QT_VERSION_CHECK
-
-    auto textLayout = doc.documentLayout();
-    Q_ASSERT(textLayout != 0);
-
+    initDocument(*document, markdown);
+    auto textLayout = document->documentLayout();
+    Q_ASSERT(textLayout != nullptr);
     return textLayout->anchorAt(point);
 }
 
@@ -44,20 +72,28 @@ void TaskDescriptionDelegate::paint(QPainter *painter,
     }
 
     painter->save();
-
-    QTextDocument document;
-    document.setTextWidth(option.rect.width());
-    document.setPageSize(option.rect.size());
-
-    QVariant value = index.data(Qt::DisplayRole);
+    const auto value = index.data(Qt::DisplayRole);
     if (value.isValid() && !value.isNull()) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-        document.setMarkdown(value.toString());
-#else
-        document.setPlainText(value.toString());
-#endif // QT_VERSION_CHECK
+        const bool elideNeeded =
+            initDocument(*document, option, value.toString());
         painter->translate(option.rect.topLeft());
-        document.drawContents(painter);
+        document->drawContents(
+            painter, { 0, 0, option.rect.width(), option.rect.height() });
+
+        // Need to add ...
+        if (elideNeeded) {
+            const QString ellipsis = QStringLiteral("…");
+            const QFontMetrics fm(option.font);
+            const int ellipsisWidth = fm.horizontalAdvance(ellipsis);
+            const QPoint ellipsisPos(option.rect.width() - ellipsisWidth,
+                                     fm.ascent());
+            painter->setPen(
+                option.palette.color((option.state & QStyle::State_Selected)
+                                         ? QPalette::HighlightedText
+                                         : QPalette::Text));
+
+            painter->drawText(ellipsisPos, ellipsis);
+        }
     }
 
     painter->restore();
@@ -68,10 +104,6 @@ QSize TaskDescriptionDelegate::sizeHint(const QStyleOptionViewItem &option,
 {
     QStyleOptionViewItem options = option;
     initStyleOption(&options, index);
-
-    QTextDocument doc;
-    doc.setHtml(options.text);
-    doc.setTextWidth(options.rect.width());
-
-    return QSize(doc.idealWidth(), doc.size().height());
+    initDocument(*document, options, options.text);
+    return { document->idealWidth(), options.rect.height() };
 }

--- a/src/taskdescriptiondelegate.cpp
+++ b/src/taskdescriptiondelegate.cpp
@@ -35,6 +35,8 @@ bool initDocument(QTextDocument &document, const QStyleOptionViewItem &option,
     initDocument(document, whole_text);
     document.setTextWidth(option.rect.width());
 
+    // Note, here we assume 1 line rows. If ever it could be more than 1 line
+    // per 1 row, it should be revised.
     const QFontMetrics fm(option.font);
     const bool elide_needed = document.size().height() / fm.height() > 1.5f;
 

--- a/src/taskdescriptiondelegate.cpp
+++ b/src/taskdescriptiondelegate.cpp
@@ -9,6 +9,7 @@
 #include <QStyledItemDelegate>
 #include <QTextDocument>
 #include <QtAssert>
+#include <QtMinMax>
 #include <QtVersionChecks>
 
 #include "taskhintproviderdelegate.hpp"
@@ -38,7 +39,8 @@ bool initDocument(QTextDocument &document, const QStyleOptionViewItem &option,
     // Note, here we assume 1 line rows. If ever it could be more than 1 line
     // per 1 row, it should be revised.
     const QFontMetrics fm(option.font);
-    const bool elide_needed = document.size().height() / fm.height() > 1.5f;
+    const bool elide_needed =
+        document.size().height() / qMax<qreal>(1.0, fm.height()) > 1.5f;
 
     document.setPageSize(option.rect.size());
 

--- a/src/taskdescriptiondelegate.hpp
+++ b/src/taskdescriptiondelegate.hpp
@@ -6,6 +6,7 @@
 #include <QString>
 #include <QStyleOptionViewItem>
 #include <QStyledItemDelegate>
+#include <QTextDocument>
 
 #include "taskhintproviderdelegate.hpp"
 
@@ -23,6 +24,9 @@ class TaskDescriptionDelegate : public TaskHintProviderDelegate {
     [[nodiscard]]
     QSize sizeHint(const QStyleOptionViewItem &option,
                    const QModelIndex &index) const override;
+
+  private:
+    QTextDocument *document;
 };
 
 #endif // TASKDESCRIPTIONDELEGATE_HPP


### PR DESCRIPTION
Fixed invalid text's wrapping:
<img width="1442" height="555" alt="image" src="https://github.com/user-attachments/assets/a9e2c91d-85bd-42b2-b1e8-4699e2832f92" />
