### PR TITLE
Tooltip shows markdown too.

### DIFF
--- a/src/qtutil.cpp
+++ b/src/qtutil.cpp
@@ -10,10 +10,11 @@
 #include <QPalette>
 #include <QString>
 #include <QStyle>
+#include <QTextDocument>
 #include <QTimeZone>
+#include <QtConfig>
+#include <QtVersionChecks>
 #include <qnamespace.h>
-#include <qtconfigmacros.h>
-#include <qtversionchecks.h>
 
 namespace
 {
@@ -160,4 +161,14 @@ bool isInteger(const QString &what)
     bool can_convert = false;
     std::ignore = what.toInt(&can_convert);
     return can_convert;
+}
+
+void setContentOfTextDocument(QTextDocument &document,
+                              const QString &whole_text)
+{
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    document.setMarkdown(whole_text);
+#else
+    document.setPlainText(whole_text);
+#endif // QT_VERSION_CHECK
 }

--- a/src/qtutil.hpp
+++ b/src/qtutil.hpp
@@ -5,6 +5,7 @@
 #include <QDate>
 #include <QDateTime>
 #include <QString>
+#include <QTextDocument>
 
 /// Adds possible shortcut information to the tooltip of the action.
 /// This provides consistent behavior both with default and custom tooltips
@@ -25,6 +26,15 @@ QDateTime startOfDay(const QDate &);
  * is 1st).
  */
 bool isOkCancelOrder();
+
+/// @returns true if @p what has string convertable to type int with decimal
+/// base.
 bool isInteger(const QString &what);
 
+/// @brief sets @p whole_text as content of @p document.
+/// @param whole_text is treated as markdown if supported by current Qt
+/// installed or plain text otherwise.
+/// @param document object to set text to.
+void setContentOfTextDocument(QTextDocument &document,
+                              const QString &whole_text);
 #endif // QTUTIL_HPP

--- a/src/taskdescriptiondelegate.cpp
+++ b/src/taskdescriptiondelegate.cpp
@@ -10,30 +10,18 @@
 #include <QTextDocument>
 #include <QtAssert>
 #include <QtMinMax>
-#include <QtVersionChecks>
 
+#include "qtutil.hpp"
 #include "taskhintproviderdelegate.hpp"
 #include "tasksmodel.hpp"
 
-// FIXME: this is sort of broken, for example it will not show \\ as markdown
-// but without markdown it will draw multiline string outside limits.
 namespace
 {
-
-void initDocument(QTextDocument &document, const QString &whole_text)
-{
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
-    document.setMarkdown(whole_text);
-#else
-    document.setPlainText(whole_text);
-#endif // QT_VERSION_CHECK
-}
-
 /// @returns true if elide is needed.
 bool initDocument(QTextDocument &document, const QStyleOptionViewItem &option,
                   const QString &whole_text)
 {
-    initDocument(document, whole_text);
+    setContentOfTextDocument(document, whole_text);
     document.setTextWidth(option.rect.width());
 
     // Note, here we assume 1 line rows. If ever it could be more than 1 line
@@ -46,8 +34,8 @@ bool initDocument(QTextDocument &document, const QStyleOptionViewItem &option,
 
     return elide_needed;
 }
-
 } // namespace
+
 TaskDescriptionDelegate::TaskDescriptionDelegate(QObject *parent)
     : TaskHintProviderDelegate(parent)
     , document(new QTextDocument(this))
@@ -57,7 +45,7 @@ TaskDescriptionDelegate::TaskDescriptionDelegate(QObject *parent)
 QString TaskDescriptionDelegate::anchorAt(const QString &markdown,
                                           const QPoint &point) const
 {
-    initDocument(*document, markdown);
+    setContentOfTextDocument(*document, markdown);
     auto textLayout = document->documentLayout();
     Q_ASSERT(textLayout != nullptr);
     return textLayout->anchorAt(point);

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -19,7 +19,6 @@
 #include <QWidget>
 #include <QtTypes>
 
-#include <iostream>
 #include <mutex>
 
 namespace

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -1,5 +1,6 @@
 #include "taskhintproviderdelegate.hpp"
 #include "async_task_loader.hpp"
+#include "qtutil.hpp"
 #include "task.hpp"
 #include "tasksmodel.hpp"
 
@@ -10,11 +11,15 @@
 #include <QStringList>
 #include <QStyleOptionViewItem>
 #include <QStyledItemDelegate>
+#include <QTextDocument>
+#include <QTextDocumentFragment>
 #include <QTimer>
 #include <QToolTip>
 #include <QVariant>
 #include <QWidget>
+#include <QtTypes>
 
+#include <iostream>
 #include <mutex>
 
 namespace
@@ -27,6 +32,30 @@ QString getLoadingTooltip(const QString &footer)
         tooltip += footer;
     }
     return tooltip;
+}
+
+QString extractQtHtmlFragment(const QString &html)
+{
+    static const QString start = "<!--StartFragment-->";
+    static const QString end = "<!--EndFragment-->";
+
+    const auto s = html.indexOf(start);
+    const auto e = html.indexOf(end);
+
+    if (s == -1 || e == -1 || e <= s) {
+        return {};
+    }
+
+    return html.mid(s + start.size(), e - (s + start.size()));
+}
+
+QString getDescriptionHtml(const QString &descr)
+{
+    QTextDocument doc;
+    setContentOfTextDocument(doc, descr);
+
+    const QTextDocumentFragment frag(&doc);
+    return extractQtHtmlFragment(frag.toHtml());
 }
 
 QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
@@ -63,7 +92,7 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
 
     const QString &descriptionStr = task.description.get();
     if (!descriptionStr.isEmpty()) {
-        html += QString("<h3>%1</h3>").arg(descriptionStr.toHtmlEscaped());
+        html += QString("<h3>%1</h3>").arg(getDescriptionHtml(descriptionStr));
     } else {
         html += QString("<p style='color:#aaa;'>ID: %1</p>").arg(task.task_id);
     }


### PR DESCRIPTION
Change tool-tip to render same markdown as table:
<img width="636" height="315" alt="image" src="https://github.com/user-attachments/assets/8cdfaa3f-e016-4f35-bc6b-12863a29be41" />
