### PR TITLE
Refactor prepare for notifications pereodics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,9 @@ cmake_minimum_required(VERSION 3.18 FATAL_ERROR)
 
 project(qtask CXX)
 
-set(QTASK_VERSION_MAJOR 1)
-set(QTASK_VERSION_MINOR 1)
-set(QTASK_VERSION_PATCH 9)
+set(QTASK_VERSION_MAJOR 1)  # something big added / changed
+set(QTASK_VERSION_MINOR 1)  # new small feature added
+set(QTASK_VERSION_PATCH 10) # refactor/bug fix inside current minor
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/src/pereodic_async_executor.hpp
+++ b/src/pereodic_async_executor.hpp
@@ -137,3 +137,11 @@ class PereodicAsynExec : public IPereodicExec {
         return var.compare_exchange_strong(exp, !expected);
     }
 };
+
+/// @returns std::unique_ptr<PereodicAsynExec<C, P,R>>
+template <typename C, typename P, typename R>
+auto createPereodicAsynExec(int ms, C c, P p, R r)
+{
+    return std::make_unique<PereodicAsynExec<C, P, R>>(
+        ms, std::move(c), std::move(p), std::move(r));
+}

--- a/src/pereodic_async_executor.hpp
+++ b/src/pereodic_async_executor.hpp
@@ -138,7 +138,8 @@ class PereodicAsynExec : public IPereodicExec {
     }
 };
 
-/// @returns std::unique_ptr<PereodicAsynExec<C, P,R>>
+/// @brief Factory method for the PereodicAsynExec.
+/// @returns std::unique_ptr<PereodicAsynExec<C, P, R>>
 template <typename C, typename P, typename R>
 auto createPereodicAsynExec(int ms, C c, P p, R r)
 {

--- a/src/pereodic_async_executor.hpp
+++ b/src/pereodic_async_executor.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <type_traits>
+
+#include <QFuture>
+#include <QFutureWatcher>
+#include <QObject>
+#include <QTimer>
+#include <QtConcurrent>
+#include <qnamespace.h>
+
+/// @note execNow() must be called at least once after construction explicit to
+/// start tracking.
+template <typename taPereodicCallable>
+class PereodicAsynExec {
+  public:
+    using ReturnType = std::decay_t<std::invoke_result_t<taPereodicCallable>>;
+
+    template <typename taResultReceiver>
+    PereodicAsynExec(const int kCheckPeriodMs, taPereodicCallable callable,
+                     taResultReceiver receiver)
+        : m_callable(callable)
+    {
+        /*
+         * setSingleShot(true) reflects a crucial architectural trade-off.
+         * * 1. Single-Shot (Current approach):
+         * The timer is explicitly restarted upon both the timer's timeout and
+         * the async operation's completion (checkNow/finished slots). This
+         * guarantees that a new check WILL NOT overlap with the previous one.
+         * The trade-off is a floating delay: the interval between checks will
+         * vary (kCheckPeriod + async_duration), sacrificing precise timing for
+         * reliability.
+         * * 2. Multi-Shot (Rejected approach):
+         * A steady, periodic timer risks starting a new check before the
+         * previous asynchronous database reading (which takes ~100ms with 9
+         * tasks present) has finished, leading to race conditions or
+         * unnecessary overlapping requests, especially when dealing with large
+         * databases.
+         */
+        m_timer.setSingleShot(true);
+        m_timer.setInterval(kCheckPeriodMs);
+        QObject::connect(&m_timer, &QTimer::timeout, &m_timer,
+                         [this]() { execNow(); });
+
+        QObject::connect(
+            &m_future_reader, &QFutureWatcher<ReturnType>::finished,
+            &m_future_reader,
+            [this, receiver]() {
+                // This is GUI thread.
+                if constexpr (!std::is_void_v<ReturnType>) {
+                    receiver(m_future_reader.future().result());
+                } else {
+                    m_future_reader.future().result();
+                    receiver();
+                }
+                m_timer.start();
+            },
+            Qt::QueuedConnection);
+    }
+
+    /// @brief Tries to execute check regardless of the current timer state.
+    /// @note It is safe to call from any thread.
+    void execNow()
+    {
+        if (!testAndFlip(m_exec_once, false)) {
+            return;
+        }
+        if (!m_future_reader.isFinished()) {
+            return;
+        }
+        const auto future = QtConcurrent::run(m_callable);
+        m_future_reader.setFuture(future);
+        m_exec_once = false;
+    }
+
+  private:
+    taPereodicCallable m_callable;
+    QFutureWatcher<ReturnType> m_future_reader;
+    QTimer m_timer;
+    std::atomic<bool> m_exec_once{ false };
+
+    static inline bool testAndFlip(std::atomic<bool> &var, const bool expected)
+    {
+        bool exp{ expected };
+        return var.compare_exchange_strong(exp, !expected);
+    }
+};

--- a/src/pereodic_async_executor.hpp
+++ b/src/pereodic_async_executor.hpp
@@ -138,7 +138,7 @@ class PereodicAsynExec : public IPereodicExec {
     }
 };
 
-/// @brief Factory method for the PereodicAsynExec.
+/// @brief Factory function for the PereodicAsynExec.
 /// @returns std::unique_ptr<PereodicAsynExec<C, P, R>>
 template <typename C, typename P, typename R>
 auto createPereodicAsynExec(int ms, C c, P p, R r)

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -3,6 +3,7 @@
 #include "date_time_parser.hpp"
 #include "qtutil.hpp"
 #include "split_string.hpp"
+#include "task_date_time.hpp"
 #include "taskwarriorexecutor.hpp"
 
 #include <QDateTime>

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -6,6 +6,7 @@
 #include "taskwarriorexecutor.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <optional>
 
 #include <QFuture>

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -29,12 +29,6 @@ constexpr int kCheckPeriod = 10000;
 // re-read list.
 constexpr auto kEnforcedCheckEach = 60min; // NOLINT
 
-template <typename C, typename P, typename R>
-auto createPeriodicWorker(int ms, C c, P p, R r)
-{
-    return std::make_unique<PereodicAsynExec<C, P, R>>(
-        ms, std::move(c), std::move(p), std::move(r));
-}
 } // namespace
 
 TaskWatcher::TaskWatcher(QObject *parent)
@@ -68,7 +62,7 @@ TaskWatcher::TaskWatcher(QObject *parent)
         }
     };
 
-    m_pereodic_worker = createPeriodicWorker(
+    m_pereodic_worker = createPereodicAsynExec(
         kCheckPeriod, std::move(threadBody), std::move(paramsForThread),
         std::move(receiverFromThread));
 }

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -1,109 +1,82 @@
 #include "taskwatcher.hpp"
 
 #include "configmanager.hpp"
-#include "exec_on_exit.hpp"
+#include "pereodic_async_executor.hpp"
 #include "task.hpp"
 #include "taskwarriorexecutor.hpp"
 
-#include <atomic>
+#include <QObject>
+#include <QString>
+
+#include <cassert>
 #include <chrono>
 #include <optional>
+#include <tuple>
+#include <utility>
 
-#include <QFuture>
-#include <QObject>
-#include <QtConcurrent>
+#include <qtmetamacros.h>
 
 namespace
 {
+using namespace std::chrono_literals;
+
 ///  @brief How often at most we will check for new data.
 // TODO: add config settings in UI instead.
 constexpr int kCheckPeriod = 10000;
 
-// tests atomic bool for expected, if it is - sets it to !expected and returns
-// true
-inline bool test_and_flip(std::atomic<bool> &var, const bool expected)
+// TaskWarrior updates order of the tasks dynamically, time/date itself may come
+// to natural border (like midnight) and TW will change the order, so we want to
+// re-read list.
+constexpr auto kEnforcedCheckEach = 60min; // NOLINT
+
+template <typename C, typename P, typename R>
+auto createPeriodicWorker(int ms, C c, P p, R r)
 {
-    bool exp{ expected };
-    return var.compare_exchange_strong(exp, !expected);
+    return std::make_unique<PereodicAsynExec<C, P, R>>(
+        ms, std::move(c), std::move(p), std::move(r));
 }
 } // namespace
 
 TaskWatcher::TaskWatcher(QObject *parent)
     : QObject(parent)
-    , m_state_reader(new QFutureWatcher<TaskWarriorDbState::Optional>(this))
     , last_check_at(std::chrono::system_clock::now())
 {
-    /*
-     * This reflects a crucial architectural trade-off.
-     * * 1. Single-Shot (Current approach):
-     * The timer is explicitly restarted upon both the timer's timeout and the
-     * async operation's completion (checkNow/finished slots). This guarantees
-     * that a new check WILL NOT overlap with the previous one.
-     * The trade-off is a floating delay: the interval between checks will vary
-     * (kCheckPeriod + async_duration), sacrificing precise timing for
-     * reliability.
-     * * 2. Multi-Shot (Rejected approach):
-     * A steady, periodic timer risks starting a new check before the previous
-     * asynchronous database reading (which takes ~100ms with 9 tasks present)
-     * has finished, leading to race conditions or unnecessary overlapping
-     * requests, especially when dealing with large databases.
-     */
-    m_check_for_changes_timer.setSingleShot(true);
-    m_check_for_changes_timer.setInterval(kCheckPeriod);
+    auto threadBody = [](QString pathToBinary) -> TaskWarriorDbState::Optional {
+        try {
+            // This is non-GUI thread.
+            return TaskWarriorDbState::readCurrent(TaskWarriorExecutor(
+                std::move(pathToBinary),
+                TaskWarriorExecutor::TSkipBinaryValidation{}));
+        } catch (...) { // NOLINT
+        }
+        return std::nullopt;
+    };
+    auto paramsForThread = []() {
+        QString path = ConfigManager::config().getTaskBin();
+        return std::make_tuple(std::move(path));
+    };
+    auto receiverFromThread = [this](TaskWarriorDbState::Optional opt) {
+        // This is GUI thread.
+        const auto now = std::chrono::system_clock::now();
+        if (now - last_check_at > kEnforcedCheckEach) {
+            enforceUpdate();
+        }
+        if (opt && opt->isDifferent(m_latestDbState)) {
+            m_latestDbState = *opt;
+            last_check_at = now;
+            emit dataOnDiskWereChanged();
+        }
+    };
 
-    connect(&m_check_for_changes_timer, &QTimer::timeout, this,
-            &TaskWatcher::checkNow);
-
-    connect(
-        m_state_reader, &QFutureWatcher<TaskWarriorDbState::Optional>::finished,
-        this,
-        [this]() {
-            // This is GUI thread.
-            using namespace std::chrono_literals;
-
-            const auto now = std::chrono::system_clock::now();
-            if (now - last_check_at > 60min) {
-                enforceUpdate();
-            }
-
-            auto opt = m_state_reader->future().result();
-            if (opt && opt->isDifferent(m_latestDbState)) {
-                m_latestDbState = *opt;
-                last_check_at = now;
-                emit dataOnDiskWereChanged();
-            }
-            m_check_for_changes_timer.start();
-        },
-        Qt::QueuedConnection);
+    m_pereodic_worker = createPeriodicWorker(
+        kCheckPeriod, std::move(threadBody), std::move(paramsForThread),
+        std::move(receiverFromThread));
 }
 
 void TaskWatcher::checkNow()
 {
-    // This slot is in progress of something, drop incoming request.
-    if (!test_and_flip(m_slot_once, false)) {
-        return;
-    }
-    if (!m_state_reader->isFinished()) {
-        return;
-    }
-    const exec_on_exit when_slot_ends([this]() {
-        m_check_for_changes_timer.start();
-        m_slot_once = false;
-    });
-
-    const auto future = QtConcurrent::run(
-        [](const auto &pathToBinary) -> TaskWarriorDbState::Optional {
-            try {
-                // This is non-GUI thread.
-                return TaskWarriorDbState::readCurrent(TaskWarriorExecutor(
-                    pathToBinary,
-                    TaskWarriorExecutor::TSkipBinaryValidation{}));
-            } catch (...) { // NOLINT
-            }
-            return std::nullopt;
-        },
-        ConfigManager::config().getTaskBin());
-    m_state_reader->setFuture(future);
+    assert(m_pereodic_worker);
+    m_pereodic_worker->execNow();
 }
 
 void TaskWatcher::enforceUpdate()

--- a/src/taskwatcher.hpp
+++ b/src/taskwatcher.hpp
@@ -1,12 +1,10 @@
 #ifndef TASKWATCHER_HPP
 #define TASKWATCHER_HPP
 
-#include <QFutureWatcher>
 #include <QObject>
-#include <QTimer>
 
-#include <atomic>
 #include <chrono>
+#include <memory>
 
 #include "pereodic_async_executor.hpp"
 #include "task.hpp"
@@ -32,12 +30,9 @@ class TaskWatcher : public QObject {
     void enforceUpdate();
 
   private:
-    struct CheckTaskState {};
-    QFutureWatcher<TaskWarriorDbState::Optional> *m_state_reader;
-    QTimer m_check_for_changes_timer;
     TaskWarriorDbState m_latestDbState;
-    std::atomic<bool> m_slot_once{ false };
     std::chrono::system_clock::time_point last_check_at;
+    std::unique_ptr<IPereodicExec> m_pereodic_worker;
 };
 
 #endif // TASKWATCHER_HPP

--- a/src/taskwatcher.hpp
+++ b/src/taskwatcher.hpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <chrono>
 
+#include "pereodic_async_executor.hpp"
 #include "task.hpp"
 
 /// @brief This object polls TaskWarrior and fires signal when re-read data is
@@ -31,6 +32,7 @@ class TaskWatcher : public QObject {
     void enforceUpdate();
 
   private:
+    struct CheckTaskState {};
     QFutureWatcher<TaskWarriorDbState::Optional> *m_state_reader;
     QTimer m_check_for_changes_timer;
     TaskWarriorDbState m_latestDbState;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -79,7 +79,9 @@ if (TESTS_LIST_FILES_COUNT GREATER 0)
     target_link_libraries(qtask_tests PRIVATE
                         gtest
                         gmock
+                        Qt${QT_VERSION_MAJOR}::Core
                         Qt${QT_VERSION_MAJOR}::Widgets
+                        Qt${QT_VERSION_MAJOR}::Concurrent
     )
     target_include_directories(qtask_tests PUBLIC
                         ${CMAKE_CURRENT_LIST_DIR}

--- a/tests/pereodic_async_executor_test.cpp
+++ b/tests/pereodic_async_executor_test.cpp
@@ -1,0 +1,120 @@
+#include "pereodic_async_executor.hpp"
+
+#include <array>
+#include <atomic>
+#include <tuple>
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QThread>
+
+#include <gtest/gtest.h>
+
+using namespace ::testing;
+
+class PereodicAsynExecTest : public ::testing::Test {
+  protected:
+    static void SetUpTestSuite()
+    {
+        static std::array<char, 5u> param = { 't', 'e', 's', 't', 0 };
+        static std::array<char *, 2u> cmd = { param.data(), nullptr };
+        static int count = static_cast<int>(cmd.size()) - 1;
+        static const QCoreApplication app(count, cmd.data());
+    }
+};
+
+TEST_F(PereodicAsynExecTest, SimpleExecutionFlow)
+{
+    QEventLoop loop;
+    int callCount = 0;
+    auto callable = [](int a, int b) { return a + b; };
+    auto provider = []() { return std::make_tuple(10, 20); };
+    auto receiver = [&](int result) {
+        EXPECT_EQ(result, 30);
+        callCount++;
+        loop.quit();
+    };
+
+    PereodicAsynExec exec(1000, callable, provider, receiver);
+    exec.execNow();
+    loop.exec();
+    EXPECT_EQ(callCount, 1);
+    loop.exec();
+    EXPECT_EQ(callCount, 2);
+}
+
+TEST_F(PereodicAsynExecTest, PeriodicRestart)
+{
+    SCOPED_TRACE("Check that timer runs thread pereodically.");
+    QEventLoop loop;
+    int callCount = 0;
+
+    auto callable = []() { return 0; };
+    auto provider = []() { return std::make_tuple(); };
+
+    auto receiver = [&](int) {
+        callCount++;
+        if (callCount == 3) {
+            loop.quit();
+        }
+    };
+
+    PereodicAsynExec exec(10, callable, provider, receiver);
+    exec.execNow();
+    loop.exec();
+
+    EXPECT_EQ(callCount, 3);
+}
+
+TEST_F(PereodicAsynExecTest, AvoidsOverlapping)
+{
+    SCOPED_TRACE(
+        "Check that fast calls to execNow() are ignored if thread is running.");
+    QEventLoop loop;
+    std::atomic<int> startCount{ 0 };
+
+    // Long callable
+    auto callable = [&](int) {
+        startCount++;
+        QThread::msleep(400);
+        return 0;
+    };
+    auto provider = []() { return std::make_tuple(1); };
+    auto receiver = [&](int) { loop.quit(); };
+
+    PereodicAsynExec exec(10, callable, provider, receiver);
+
+    exec.execNow();
+    QThread::msleep(100);
+    exec.execNow();
+    loop.exec();
+    QThread::msleep(100);
+    EXPECT_EQ(startCount.load(), 1);
+}
+
+TEST_F(PereodicAsynExecTest, DestructorSafety)
+{
+    std::atomic<bool> threadStarted{ false };
+    std::atomic<bool> threadFinished{ false };
+
+    auto callable = [&](int) {
+        threadStarted = true;
+        QThread::msleep(300);
+        threadFinished = true;
+        return 42;
+    };
+    auto provider = []() { return std::make_tuple(1); };
+    auto receiver = [](int) { /* Nothing*/ };
+    {
+        PereodicAsynExec exec(100, callable, provider, receiver);
+        exec.execNow();
+
+        // Wait while thread is started.
+        while (!threadStarted) {
+            QCoreApplication::processEvents();
+        }
+        SCOPED_TRACE(
+            "Destructor is out of scope and must block until thread finished.");
+    }
+    EXPECT_TRUE(threadFinished) << "Callable had to finish.";
+}


### PR DESCRIPTION
Refactor `class TaskWatcher`. I moved out generic logic "check something periodically and async" to dedicated class `PereodicAsynExec` with tests.
Now everything should be prepared to add notifications.
