### PR TITLE
Status emoji

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.20 FATAL_ERROR)
 project(qtask CXX)
 
 set(QTASK_VERSION_MAJOR 1)  # something big added / changed
-set(QTASK_VERSION_MINOR 1)  # new small feature added
-set(QTASK_VERSION_PATCH 10) # refactor/bug fix inside current minor
+set(QTASK_VERSION_MINOR 2)  # new small feature added
+set(QTASK_VERSION_PATCH 0) # refactor/bug fix inside current minor
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,10 +58,11 @@ find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS ${QT_COMPONENTS_WE_NEED})
 #Private package is different on distributions
 if(TARGET Qt${QT_VERSION_MAJOR}::GuiPrivate)
     # Debian just adds it silently.
-    message(STATUS "Qt${QT_VERSION_MAJOR}::GuiPrivate already defined by system")
+    message(STATUS "Qt${QT_VERSION_MAJOR}::GuiPrivate is already defined by system.")
     set(Qt${QT_VERSION_MAJOR}GuiPrivate_FOUND TRUE)
 else()
     #Arch linux, we need explicit search.
+    message(STATUS "Checking for dedicated package Qt${QT_VERSION_MAJOR}::GuiPrivate.")
     find_package(Qt${QT_VERSION_MAJOR} COMPONENTS GuiPrivate QUIET)
 endif()
 
@@ -69,7 +70,7 @@ endif()
 if(NOT TARGET Qt${QT_VERSION_MAJOR}::GuiPrivate)
 
     set(QT_PRIVATE_INCLUDE_DIRS "")
-    message(STATUS "Searching for Qt ${QT_VERSION} private headers...")
+    message(STATUS "Searching for Qt ${QT_VERSION} private headers on disk...")
 
     # Option 1
     set(_check_targets Qt${QT_VERSION_MAJOR}::Core Qt${QT_VERSION_MAJOR}::Gui)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -685,13 +685,24 @@ void MainWindow::onEnterTaskCommand()
 
 void MainWindow::showEditTaskDialog([[maybe_unused]] const QModelIndex &idx)
 {
-    const auto *model = m_tasks_view->selectionModel();
-    const auto id_str = model->selectedRows()[0].data().toString();
+    const auto selected = m_tasks_view->selectionModel()->selectedRows();
+    if (selected.isEmpty())
+        return;
+    const QVariant taskVar = selected[0].data(TasksModel::TaskReadRole);
+    if (!taskVar.canConvert<DetailedTaskInfo>()) {
+        refreshTasksListTableIfNeeded();
+        return;
+    }
+
+    const auto taskInModel = taskVar.value<DetailedTaskInfo>();
+    const auto &id_str = taskInModel.task_id;
+
     if (id_str.isEmpty()) {
         refreshTasksListTableIfNeeded();
         return;
     }
 
+    // Do we really want to read full task again?
     const auto task = m_task_provider->getTask(id_str);
     if (!task) {
         refreshTasksListTableIfNeeded();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -128,6 +128,11 @@ bool MainWindow::initTaskWatcher()
                                 getSelectedTaskIds());
 
                 updateTaskToolbar();
+                if (m_tasks_view) {
+                    QTimer::singleShot(50, m_tasks_view, [this]() {
+                        m_tasks_view->resizeColumnToContents(0);
+                    });
+                }
             }
         });
     return true;
@@ -169,7 +174,8 @@ void MainWindow::initTasksTable()
     m_tasks_view->verticalHeader()->setVisible(false);
     m_tasks_view->horizontalHeader()->setStretchLastSection(true);
     m_tasks_view->setSelectionBehavior(QAbstractItemView::SelectRows);
-
+    m_tasks_view->horizontalHeader()->setSectionResizeMode(
+        0, QHeaderView::ResizeToContents);
     auto *model = new TasksModel(this);
     m_tasks_view->setModel(model);
 

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -60,7 +60,7 @@ class MainWindow : public QMainWindow {
 
     [[nodiscard]] std::optional<QString> getSelectedTaskId() const;
     [[nodiscard]] QStringList getSelectedTaskIds() const;
-
+    [[nodiscard]] QList<DetailedTaskInfo> getSelectedTaskInModel() const;
   public slots:
     /// Add entry to tags filter
     void pushFilterTag(const QString &);

--- a/src/optionaldatetimeedit.hpp
+++ b/src/optionaldatetimeedit.hpp
@@ -23,9 +23,12 @@ class OptionalDateTimeEdit : public QWidget {
     template <ETaskDateTimeRole taRole>
     TaskDateTime<taRole> getDateTime() const
     {
-        return (m_enabled->isChecked())
-                   ? TaskDateTime<taRole>(m_datetime_edit->dateTime())
-                   : TaskDateTime<taRole>();
+        if (!m_enabled->isChecked()) {
+            return TaskDateTime<taRole>();
+        }
+        QDateTime dt = m_datetime_edit->dateTime();
+        dt.setTime(QTime(dt.time().hour(), dt.time().minute(), 0, 0));
+        return TaskDateTime<taRole>(dt);
     }
     void setDateTime(const QDateTime &dt);
 

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -525,7 +525,7 @@ FilteredTasksListReader::FilteredTasksListReader(AllAtOnceKeywordsFinder filter)
 
 bool FilteredTasksListReader::readTaskList(const TaskWarriorExecutor &executor)
 {
-    constexpr qsizetype kExpectedColumnsCount = 6;
+    constexpr qsizetype kExpectedColumnsCount = 7;
 
     if (m_filter.isNotFound()) {
         tasks.clear();
@@ -534,9 +534,9 @@ bool FilteredTasksListReader::readTaskList(const TaskWarriorExecutor &executor)
 
     auto cmd = QStringList{
         // clang-format off
-                         "rc.report.minimal.columns=id,start.active,project,priority,scheduled,due,description",
+                         "rc.report.minimal.columns=id,start.active,project,priority,scheduled,due,wait,description",
         // clang-format on
-        "rc.report.minimal.labels=',|,|,|,|,|,|'",
+        "rc.report.minimal.labels=',|,|,|,|,|,|,|'",
         "rc.report.minimal.sort=urgency-",
         "rc.print.empty.columns=yes",
         "rc.dateformat=Y-M-DTH:N:S",
@@ -624,7 +624,13 @@ bool FilteredTasksListReader::readTaskList(const TaskWarriorExecutor &executor)
         if (due.isValid()) {
             task.due = due;
         }
-        task.description = line.right(line.size() - positions[5]).simplified();
+        auto wait = QDateTime::fromString(
+            line.mid(positions[5], positions[6] - positions[5]).simplified(),
+            Qt::ISODate);
+        if (wait.isValid()) {
+            task.wait = wait;
+        }
+        task.description = line.right(line.size() - positions[6]).simplified();
         tasks.emplace_back(std::move(task));
     }
 

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -9,6 +9,7 @@
 #include <qvariant.h>
 
 #include <algorithm>
+#include <cstddef>
 #include <cstdint>
 #include <iterator>
 #include <optional>
@@ -72,6 +73,14 @@ class DetailedTaskInfo {
     /// @returns true if this object has all possible data read from `task`.
     [[nodiscard]]
     bool isFullRead() const;
+
+    void markFullRead() { dataState = ReadAs::FullRead; }
+
+    [[nodiscard]]
+    static constexpr std::size_t propertiesCount()
+    {
+        return std::tuple_size_v<decltype(std::tie(TASK_PROPERTIES_LIST))>;
+    }
 
   public:
     /// @brief Constructs object with defaults, except given @p task_id set.

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -5,15 +5,23 @@
 #include <QList>
 #include <QString>
 #include <QStringList>
+#include <qtypes.h>
 #include <qvariant.h>
 
+#include <algorithm>
 #include <cstdint>
+#include <iterator>
 #include <optional>
 #include <tuple>
+#include <type_traits>
 
 #include "task_date_time.hpp"
 #include "taskproperty.hpp"
 #include "taskwarriorexecutor.hpp"
+
+// This should contain ALL TaskProperty<> fields in DetailedTaskInfo.
+#define TASK_PROPERTIES_LIST \
+    priority, project, tags, sched, due, wait, description, active
 
 /// @note Classes here are responsible to produce proper commands to the
 /// taskwarrior and parse it's results intact with own fields. Actual execution
@@ -30,6 +38,8 @@ class DetailedTaskInfo {
     // track modification.
     QString task_id;
 
+    // Note, update TASK_PROPERTIES_LIST macros if you add/remove some
+    // here.
     TaskProperty<QString> description;
     TaskProperty<QString> project;
     TaskProperty<QStringList> tags; // current tags list
@@ -37,8 +47,7 @@ class DetailedTaskInfo {
     TaskProperty<TaskDateTime<ETaskDateTimeRole::Due>> due;
     TaskProperty<TaskDateTime<ETaskDateTimeRole::Wait>> wait;
     TaskProperty<Priority> priority;
-
-    bool active{ false };
+    TaskProperty<bool> active;
 
     /// @brief Copies different fields from @p other object. If field was equal,
     /// keeps "modified" state as it was before.
@@ -82,9 +91,31 @@ class DetailedTaskInfo {
 
     [[nodiscard]]
     QStringList getAddModifyCmdArgsFieldsRepresentation() const;
+
+    [[nodiscard]]
+    auto asTuple()
+    {
+        return std::tie(TASK_PROPERTIES_LIST);
+    }
+    [[nodiscard]] auto asTuple() const
+    {
+        return std::tie(TASK_PROPERTIES_LIST);
+    }
 };
 
 Q_DECLARE_METATYPE(DetailedTaskInfo)
+
+template <typename taTasksContainer>
+QStringList tasksListToIds(const taTasksContainer &tasks)
+{
+    QStringList ids;
+    ids.reserve(static_cast<qsizetype>(
+        std::distance(std::begin(tasks), std::end(tasks))));
+    std::transform(
+        std::begin(tasks), std::end(tasks), std::back_inserter(ids),
+        [](const DetailedTaskInfo &task) -> QString { return task.task_id; });
+    return ids;
+}
 
 /// @brief This object allows Start/Stop/Done/Delete task(s) (1 or more at
 /// once).

--- a/src/task_date_time.hpp
+++ b/src/task_date_time.hpp
@@ -2,7 +2,6 @@
 
 #include <QDateTime>
 #include <QString>
-#include <qnamespace.h>
 
 #include <chrono>
 #include <cstdint>

--- a/src/task_emojies.hpp
+++ b/src/task_emojies.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "task.hpp"
+#include "task_date_time.hpp"
+
+#include <QDateTime>
+#include <QFontDatabase>
+#include <QFontMetrics>
+#include <QGuiApplication>
+#include <QString>
+
+#include <QFont>
+#include <QFontDatabase>
+#include <QFontMetrics>
+#include <QGuiApplication>
+#include <QString>
+#include <QStringLiteral>
+
+/// @brief Computes DatesRelation between @p taskDate and @p now and converts to
+/// emoji if supported, to text string otherwise.
+/// @returns string oe emojies or text.
+template <ETaskDateTimeRole taRole>
+QString relationToEmoji(const TaskDateTime<taRole> &taskDate,
+                        const QDateTime &now = QDateTime::currentDateTime())
+{
+    static const bool hasEmoji = []() {
+        const QFont font = QGuiApplication::font();
+        const QFontMetrics metrics(font);
+        return metrics.inFontUcs4(0x1F525); // 🔥
+    }();
+    const auto rel = taskDate.relationToNow(now);
+
+    if constexpr (taRole == ETaskDateTimeRole::Due) {
+        switch (rel) {
+        case DatesRelation::Past:
+            return hasEmoji ? QString::fromUtf8("🔥") : QStringLiteral("[!]");
+        case DatesRelation::Approaching:
+            return hasEmoji ? QString::fromUtf8("⚠️") : QStringLiteral("(>)");
+        case DatesRelation::Future:
+            return hasEmoji ? QString::fromUtf8("📌") : QStringLiteral("[ ]");
+        }
+    } else if constexpr (taRole == ETaskDateTimeRole::Sched) {
+        switch (rel) {
+        case DatesRelation::Past:
+            return hasEmoji ? QString::fromUtf8("📢") : QStringLiteral("(+)");
+        case DatesRelation::Approaching:
+            return hasEmoji ? QString::fromUtf8("⏳") : QStringLiteral("(:)");
+        case DatesRelation::Future:
+            return hasEmoji ? QString::fromUtf8("💤") : QStringLiteral("...");
+        }
+    } else if constexpr (taRole == ETaskDateTimeRole::Wait) {
+        if (rel == DatesRelation::Past) {
+            return hasEmoji ? QString::fromUtf8("👁️") : QStringLiteral(" * ");
+        }
+        return hasEmoji ? QString::fromUtf8("⏸️") : QStringLiteral(" z ");
+    }
+
+    return {};
+}
+
+/// @brief Converts 3 dates of the @p task to emojies using relationToEmoji()
+/// and @returns joined result of 3 conversions.
+/// @note If date was not set it will be skip.
+inline QString
+taskToTimeEmojies(const DetailedTaskInfo &task,
+                  const QDateTime &now = QDateTime::currentDateTime())
+{
+    QStringList icons;
+    if (task.due.get().has_value()) {
+        icons << relationToEmoji(task.due.get(), now);
+    }
+    if (task.sched.get().has_value()) {
+        icons << relationToEmoji(task.sched.get(), now);
+    }
+    if (task.wait.get().has_value()) {
+
+        icons << relationToEmoji(task.wait.get(), now);
+    }
+    icons.removeAll(QString());
+    return icons.join(" ");
+}

--- a/src/task_emojies.hpp
+++ b/src/task_emojies.hpp
@@ -16,66 +16,110 @@
 #include <QString>
 #include <QStringLiteral>
 
-/// @brief Computes DatesRelation between @p taskDate and @p now and converts to
-/// emoji if supported, to text string otherwise.
-/// @returns string oe emojies or text.
-template <ETaskDateTimeRole taRole>
-QString relationToEmoji(const TaskDateTime<taRole> &taskDate,
-                        const QDateTime &now = QDateTime::currentDateTime())
-{
-    static const bool hasEmoji = []() {
-        const QFont font = QGuiApplication::font();
-        const QFontMetrics metrics(font);
-        return metrics.inFontUcs4(0x1F525); // 🔥
-    }();
-    const auto rel = taskDate.relationToNow(now);
+class StatusEmoji {
+  public:
+    explicit StatusEmoji(const DetailedTaskInfo &task,
+                         QDateTime now = QDateTime::currentDateTime())
+        : task(task)
+        , now(std::move(now))
+    {
+    }
+    [[nodiscard]]
+    QString combinedEmoji() const
+    {
+        QStringList icons;
+        icons << schedEmoji() << dueEmoji() << waitEmoji();
+        icons.removeAll(QString());
+        return icons.join(QString::fromUtf8("\u2007"));
+    }
 
-    if constexpr (taRole == ETaskDateTimeRole::Due) {
-        switch (rel) {
-        case DatesRelation::Past:
-            return hasEmoji ? QString::fromUtf8("🔥") : QStringLiteral("[!]");
-        case DatesRelation::Approaching:
-            return hasEmoji ? QString::fromUtf8("⚠️") : QStringLiteral("(>)");
-        case DatesRelation::Future:
-            return hasEmoji ? QString::fromUtf8("📌") : QStringLiteral("[ ]");
+    [[nodiscard]]
+    QString dueEmoji() const
+    {
+        if (task.due.get().has_value()) {
+            return relationToEmoji(task.due.get(), now);
         }
-    } else if constexpr (taRole == ETaskDateTimeRole::Sched) {
-        switch (rel) {
-        case DatesRelation::Past:
-            return hasEmoji ? QString::fromUtf8("📢") : QStringLiteral("(+)");
-        case DatesRelation::Approaching:
-            return hasEmoji ? QString::fromUtf8("⏳") : QStringLiteral("(:)");
-        case DatesRelation::Future:
-            return hasEmoji ? QString::fromUtf8("💤") : QStringLiteral("...");
+        return {};
+    }
+
+    [[nodiscard]]
+    QString waitEmoji() const
+    {
+        if (task.wait.get().has_value()) {
+            return relationToEmoji(task.wait.get(), now);
         }
-    } else if constexpr (taRole == ETaskDateTimeRole::Wait) {
-        if (rel == DatesRelation::Past) {
-            return hasEmoji ? QString::fromUtf8("👁️") : QStringLiteral(" * ");
+        return {};
+    }
+
+    [[nodiscard]]
+    QString schedEmoji() const
+    {
+        if (isSpecialSched()) {
+            return QString::fromUtf8("🔵");
         }
-        return hasEmoji ? QString::fromUtf8("⏸️") : QStringLiteral(" z ");
+        if (task.sched.get().has_value()) {
+            return relationToEmoji(task.sched.get(), now);
+        }
+        return {};
     }
 
-    return {};
-}
+    [[nodiscard]]
+    bool isSpecialSched() const
+    {
+        return task.active.get();
+    }
 
-/// @brief Converts 3 dates of the @p task to emojies using relationToEmoji()
-/// and @returns joined result of 3 conversions.
-/// @note If date was not set it will be skip.
-inline QString
-taskToTimeEmojies(const DetailedTaskInfo &task,
-                  const QDateTime &now = QDateTime::currentDateTime())
-{
-    QStringList icons;
-    if (task.due.get().has_value()) {
-        icons << relationToEmoji(task.due.get(), now);
-    }
-    if (task.sched.get().has_value()) {
-        icons << relationToEmoji(task.sched.get(), now);
-    }
-    if (task.wait.get().has_value()) {
+  private:
+    const DetailedTaskInfo &task;
+    QDateTime now;
 
-        icons << relationToEmoji(task.wait.get(), now);
+    /// @brief Computes DatesRelation between @p taskDate and @p now and
+    /// converts to emoji if supported, to text string otherwise.
+    /// @returns string oe emojies or text.
+    template <ETaskDateTimeRole taRole>
+    [[nodiscard]] QString static relationToEmoji(
+        const TaskDateTime<taRole> &taskDate,
+        const QDateTime &now = QDateTime::currentDateTime())
+    {
+        static const bool hasEmoji = []() {
+            const QFont font = QGuiApplication::font();
+            const QFontMetrics metrics(font);
+            return metrics.inFontUcs4(0x1F525); // 🔥
+        }();
+        const auto rel = taskDate.relationToNow(now);
+
+        if constexpr (taRole == ETaskDateTimeRole::Due) {
+            switch (rel) {
+            case DatesRelation::Past:
+                return hasEmoji ? QString::fromUtf8("🔥")
+                                : QStringLiteral("[!]");
+            case DatesRelation::Approaching:
+                return hasEmoji ? QString::fromUtf8("⚠️")
+                                : QStringLiteral("(>)");
+            case DatesRelation::Future:
+                return hasEmoji ? QString::fromUtf8("🗓️")
+                                : QStringLiteral("[ ]");
+            }
+        } else if constexpr (taRole == ETaskDateTimeRole::Sched) {
+            switch (rel) {
+            case DatesRelation::Past:
+                return hasEmoji ? QString::fromUtf8("🚀")
+                                : QStringLiteral("(+)");
+            case DatesRelation::Approaching:
+                return hasEmoji ? QString::fromUtf8("⏳")
+                                : QStringLiteral("(:)");
+            case DatesRelation::Future:
+                return hasEmoji ? QString::fromUtf8("💤")
+                                : QStringLiteral("...");
+            }
+        } else if constexpr (taRole == ETaskDateTimeRole::Wait) {
+            if (rel == DatesRelation::Past) {
+                return hasEmoji ? QString::fromUtf8("👁️")
+                                : QStringLiteral(" * ");
+            }
+            return hasEmoji ? QString::fromUtf8("⏸️") : QStringLiteral(" z ");
+        }
+
+        return {};
     }
-    icons.removeAll(QString());
-    return icons.join(QString::fromUtf8("\u2007"));
-}
+};

--- a/src/task_emojies.hpp
+++ b/src/task_emojies.hpp
@@ -55,7 +55,7 @@ class StatusEmoji {
     QString schedEmoji() const
     {
         if (isSpecialSched()) {
-            return QString::fromUtf8("🔵");
+            return hasEmoji() ? QString::fromUtf8("🔵") : "[W]";
         }
         if (task.sched.get().has_value()) {
             return relationToEmoji(task.sched.get(), now);
@@ -73,6 +73,16 @@ class StatusEmoji {
     const DetailedTaskInfo &task;
     QDateTime now;
 
+    static bool hasEmoji()
+    {
+        static const bool has_emoji = []() {
+            const QFont font = QGuiApplication::font();
+            const QFontMetrics metrics(font);
+            return metrics.inFontUcs4(0x1F525); // 🔥
+        }();
+        return has_emoji;
+    }
+
     /// @brief Computes DatesRelation between @p taskDate and @p now and
     /// converts to emoji if supported, to text string otherwise.
     /// @returns string oe emojies or text.
@@ -81,43 +91,38 @@ class StatusEmoji {
         const TaskDateTime<taRole> &taskDate,
         const QDateTime &now = QDateTime::currentDateTime())
     {
-        static const bool hasEmoji = []() {
-            const QFont font = QGuiApplication::font();
-            const QFontMetrics metrics(font);
-            return metrics.inFontUcs4(0x1F525); // 🔥
-        }();
         const auto rel = taskDate.relationToNow(now);
 
         if constexpr (taRole == ETaskDateTimeRole::Due) {
             switch (rel) {
             case DatesRelation::Past:
-                return hasEmoji ? QString::fromUtf8("🔥")
-                                : QStringLiteral("[!]");
+                return hasEmoji() ? QString::fromUtf8("🔥")
+                                  : QStringLiteral("[!]");
             case DatesRelation::Approaching:
-                return hasEmoji ? QString::fromUtf8("⚠️")
-                                : QStringLiteral("(>)");
+                return hasEmoji() ? QString::fromUtf8("⚠️")
+                                  : QStringLiteral("(>)");
             case DatesRelation::Future:
-                return hasEmoji ? QString::fromUtf8("🗓️")
-                                : QStringLiteral("[ ]");
+                return hasEmoji() ? QString::fromUtf8("🗓️")
+                                  : QStringLiteral("[ ]");
             }
         } else if constexpr (taRole == ETaskDateTimeRole::Sched) {
             switch (rel) {
             case DatesRelation::Past:
-                return hasEmoji ? QString::fromUtf8("🚀")
-                                : QStringLiteral("(+)");
+                return hasEmoji() ? QString::fromUtf8("🚀")
+                                  : QStringLiteral("(+)");
             case DatesRelation::Approaching:
-                return hasEmoji ? QString::fromUtf8("⏳")
-                                : QStringLiteral("(:)");
+                return hasEmoji() ? QString::fromUtf8("⏳")
+                                  : QStringLiteral("(:)");
             case DatesRelation::Future:
-                return hasEmoji ? QString::fromUtf8("💤")
-                                : QStringLiteral("...");
+                return hasEmoji() ? QString::fromUtf8("💤")
+                                  : QStringLiteral("...");
             }
         } else if constexpr (taRole == ETaskDateTimeRole::Wait) {
             if (rel == DatesRelation::Past) {
-                return hasEmoji ? QString::fromUtf8("👁️")
-                                : QStringLiteral(" * ");
+                return hasEmoji() ? QString::fromUtf8("👁️")
+                                  : QStringLiteral(" * ");
             }
-            return hasEmoji ? QString::fromUtf8("⏸️") : QStringLiteral(" z ");
+            return hasEmoji() ? QString::fromUtf8("⏸️") : QStringLiteral(" z ");
         }
 
         return {};

--- a/src/task_emojies.hpp
+++ b/src/task_emojies.hpp
@@ -77,5 +77,5 @@ taskToTimeEmojies(const DetailedTaskInfo &task,
         icons << relationToEmoji(task.wait.get(), now);
     }
     icons.removeAll(QString());
-    return icons.join(" ");
+    return icons.join(QString::fromUtf8("\u2007"));
 }

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -73,11 +73,25 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
                    "5px; margin-top: 5px; }"
                    ".priority-high { color: red; font-weight: bold; }"
                    ".date-due { color: #8e44ad; font-weight: bold; }"
-                   ".tag-list { padding-left: 20px; margin: 0; }"
                    ".date-overdue { color: red; font-weight: bold; }"
                    ".date-approaching { color: orange; font-weight: bold; }"
                    ".date-normal { color: #555; }"
                    ".date-active {color: #005fb8;font-weight: bold;}"
+                   ".tag-list {"
+                   "  list-style-type: none;"
+                   "  padding: 0;"
+                   "  margin: 0;"
+                   "  display: flex;"
+                   "  flex-wrap: wrap;"
+                   "}"
+                   ".tag-list li {"
+                   "  background: #f0f0f0;"
+                   "  padding: 2px 6px;"
+                   "  margin: 2px;"
+                   "  display: inline-block;"
+                   "  color: #333;"
+                   "  font-size: 11px;"
+                   "}"
                    "</style>";
 
     static const auto getDateCssClass = [](const auto &dt) -> QString {
@@ -163,11 +177,9 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
     // ------------------------------------------------
     const QStringList &tagsList = task.tags.get();
     if (!tagsList.isEmpty()) {
-        html += "<div class='info-block'><h3>Tags</h3><ul class='tag-list'>";
-        for (const QString &tag : tagsList) {
-            html += QString("<li>%1</li>").arg(tag.toHtmlEscaped());
-        }
-        html += "</ul></div>";
+        html += "<div class='info-block'><h3>Tags</h3><p>";
+        html += tagsList.join(", "); // Просто перечисление через запятую
+        html += "</p></div>";
     }
 
     // ------------------------------------------------

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -126,15 +126,6 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
     if (hasDates) {
         html += "<div class='info-block'><h3>Dates</h3>";
 
-        // DUE DATE
-        if (optionalDue.has_value()) {
-            const QString dateStr = optionalDue.value().toString();
-            const QString cssClass = getDateCssClass(optionalDue);
-            html += QString("<p class='date-due'><span class='%1'>%3&nbsp;Due: "
-                            "%2</span></p>")
-                        .arg(cssClass, dateStr, status.dueEmoji());
-        }
-
         // SCHED DATE
         if (optionalSched.has_value()) {
             const QString dateStr = optionalSched.value().toString();
@@ -144,6 +135,15 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
             html +=
                 QString("<p><span class='%1'>%3&nbsp;Scheduled: %2</span></p>")
                     .arg(cssClass, dateStr, status.schedEmoji());
+        }
+
+        // DUE DATE
+        if (optionalDue.has_value()) {
+            const QString dateStr = optionalDue.value().toString();
+            const QString cssClass = getDateCssClass(optionalDue);
+            html += QString("<p class='date-due'><span class='%1'>%3&nbsp;Due: "
+                            "%2</span></p>")
+                        .arg(cssClass, dateStr, status.dueEmoji());
         }
 
         // WAIT DATE

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -2,6 +2,8 @@
 #include "async_task_loader.hpp"
 #include "qtutil.hpp"
 #include "task.hpp"
+#include "task_date_time.hpp"
+#include "task_emojies.hpp"
 #include "tasksmodel.hpp"
 
 #include <QAbstractItemView>
@@ -20,6 +22,7 @@
 #include <QtTypes>
 
 #include <mutex>
+#include <stdexcept>
 
 namespace
 {
@@ -125,29 +128,28 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
         if (optionalDue.has_value()) {
             const QString dateStr = optionalDue.value().toString();
             const QString cssClass = getDateCssClass(optionalDue);
-
-            html +=
-                QString(
-                    "<p class='date-due'><span class='%1'>Due: %2</span></p>")
-                    .arg(cssClass, dateStr);
+            const QString icon = relationToEmoji(optionalDue);
+            html += QString("<p class='date-due'><span class='%1'>%3 Due: "
+                            "%2</span></p>")
+                        .arg(cssClass, dateStr, icon);
         }
 
         // SCHED DATE
         if (optionalSched.has_value()) {
             const QString dateStr = optionalSched.value().toString();
             const QString cssClass = getDateCssClass(optionalSched);
-
-            html += QString("<p><span class='%1'>Scheduled: %2</span></p>")
-                        .arg(cssClass, dateStr);
+            const QString icon = relationToEmoji(optionalSched);
+            html += QString("<p><span class='%1'>%3 Scheduled: %2</span></p>")
+                        .arg(cssClass, dateStr, icon);
         }
 
         // WAIT DATE
         if (optionalWait.has_value()) {
             const QString dateStr = optionalWait.value().toString();
             const QString cssClass = getDateCssClass(optionalWait);
-
-            html += QString("<p><span class='%1'>Wait until: %2</span></p>")
-                        .arg(cssClass, dateStr);
+            const QString icon = relationToEmoji(optionalWait);
+            html += QString("<p><span class='%1'>%3 Wait until: %2</span></p>")
+                        .arg(cssClass, dateStr, icon);
         }
 
         html += "</div>";

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -77,6 +77,7 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
                    ".date-overdue { color: red; font-weight: bold; }"
                    ".date-approaching { color: orange; font-weight: bold; }"
                    ".date-normal { color: #555; }"
+                   ".date-active {color: #005fb8;font-weight: bold;}"
                    "</style>";
 
     static const auto getDateCssClass = [](const auto &dt) -> QString {
@@ -118,6 +119,7 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
     const auto &optionalDue = task.due.get();
     const auto &optionalSched = task.sched.get();
     const auto &optionalWait = task.wait.get();
+    const StatusEmoji status(task);
 
     const bool hasDates = optionalDue.has_value() ||
                           optionalSched.has_value() || optionalWait.has_value();
@@ -128,28 +130,29 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
         if (optionalDue.has_value()) {
             const QString dateStr = optionalDue.value().toString();
             const QString cssClass = getDateCssClass(optionalDue);
-            const QString icon = relationToEmoji(optionalDue);
-            html += QString("<p class='date-due'><span class='%1'>%3 Due: "
+            html += QString("<p class='date-due'><span class='%1'>%3&nbsp;Due: "
                             "%2</span></p>")
-                        .arg(cssClass, dateStr, icon);
+                        .arg(cssClass, dateStr, status.dueEmoji());
         }
 
         // SCHED DATE
         if (optionalSched.has_value()) {
             const QString dateStr = optionalSched.value().toString();
-            const QString cssClass = getDateCssClass(optionalSched);
-            const QString icon = relationToEmoji(optionalSched);
-            html += QString("<p><span class='%1'>%3 Scheduled: %2</span></p>")
-                        .arg(cssClass, dateStr, icon);
+            const QString cssClass = status.isSpecialSched()
+                                         ? "date-active"
+                                         : getDateCssClass(optionalSched);
+            html +=
+                QString("<p><span class='%1'>%3&nbsp;Scheduled: %2</span></p>")
+                    .arg(cssClass, dateStr, status.schedEmoji());
         }
 
         // WAIT DATE
         if (optionalWait.has_value()) {
             const QString dateStr = optionalWait.value().toString();
             const QString cssClass = getDateCssClass(optionalWait);
-            const QString icon = relationToEmoji(optionalWait);
-            html += QString("<p><span class='%1'>%3 Wait until: %2</span></p>")
-                        .arg(cssClass, dateStr, icon);
+            html +=
+                QString("<p><span class='%1'>%3&nbsp;Wait until: %2</span></p>")
+                    .arg(cssClass, dateStr, status.waitEmoji());
         }
 
         html += "</div>";

--- a/src/taskhintproviderdelegate.cpp
+++ b/src/taskhintproviderdelegate.cpp
@@ -60,6 +60,12 @@ QString getDescriptionHtml(const QString &descr)
     return extractQtHtmlFragment(frag.toHtml());
 }
 
+QString toString(const QDateTime &dt)
+{
+    // Avoiding seconds in output.
+    return QLocale::system().toString(dt, QLocale::ShortFormat);
+}
+
 QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
 {
     if (!task.isFullRead()) {
@@ -142,7 +148,7 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
 
         // SCHED DATE
         if (optionalSched.has_value()) {
-            const QString dateStr = optionalSched.value().toString();
+            const QString dateStr = toString(optionalSched.value());
             const QString cssClass = status.isSpecialSched()
                                          ? "date-active"
                                          : getDateCssClass(optionalSched);
@@ -153,7 +159,7 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
 
         // DUE DATE
         if (optionalDue.has_value()) {
-            const QString dateStr = optionalDue.value().toString();
+            const QString dateStr = toString(optionalDue.value());
             const QString cssClass = getDateCssClass(optionalDue);
             html += QString("<p class='date-due'><span class='%1'>%3&nbsp;Due: "
                             "%2</span></p>")
@@ -162,7 +168,7 @@ QString generateTooltip(const DetailedTaskInfo &task, const QString &footer)
 
         // WAIT DATE
         if (optionalWait.has_value()) {
-            const QString dateStr = optionalWait.value().toString();
+            const QString dateStr = toString(optionalWait.value());
             const QString cssClass = getDateCssClass(optionalWait);
             html +=
                 QString("<p><span class='%1'>%3&nbsp;Wait until: %2</span></p>")

--- a/src/tasksmodel.cpp
+++ b/src/tasksmodel.cpp
@@ -58,7 +58,7 @@ QVariant TasksModel::data(const QModelIndex &index, int role) const
         return { Qt::AlignVCenter | Qt::AlignLeft };
     case Qt::DecorationRole:
         if (index.column() == 0) {
-            return (m_tasks.at(index.row()).active)
+            return (m_tasks.at(index.row()).active.get())
                        ? QIcon(":/icons/active.svg")
                        : QVariant{};
         }

--- a/src/tasksmodel.cpp
+++ b/src/tasksmodel.cpp
@@ -1,4 +1,5 @@
 #include "tasksmodel.hpp"
+#include "task_emojies.hpp"
 
 #include <utility>
 
@@ -42,7 +43,7 @@ QVariant TasksModel::data(const QModelIndex &index, int role) const
     case Qt::DisplayRole: {
         switch (index.column()) {
         case 0:
-            return task.task_id;
+            return taskToTimeEmojies(task) + task.task_id;
         case 1:
             return task.project.get();
         case 2:

--- a/src/tasksmodel.cpp
+++ b/src/tasksmodel.cpp
@@ -42,8 +42,14 @@ QVariant TasksModel::data(const QModelIndex &index, int role) const
     switch (role) {
     case Qt::DisplayRole: {
         switch (index.column()) {
-        case 0:
-            return task.task_id + taskToTimeEmojies(task);
+        case 0: {
+            const StatusEmoji status(task);
+            const QString emojis = status.combinedEmoji();
+            if (emojis.isEmpty()) {
+                return task.task_id;
+            }
+            return " " + task.task_id + " " + emojis + " ";
+        }
         case 1:
             return task.project.get();
         case 2:
@@ -56,13 +62,6 @@ QVariant TasksModel::data(const QModelIndex &index, int role) const
     }
     case Qt::TextAlignmentRole:
         return { Qt::AlignVCenter | Qt::AlignLeft };
-    case Qt::DecorationRole:
-        if (index.column() == 0) {
-            return (m_tasks.at(index.row()).active.get())
-                       ? QIcon(":/icons/active.svg")
-                       : QVariant{};
-        }
-        break;
     case Qt::BackgroundRole:
         return QVariant(QBrush(rowColor(index.row())));
     case TaskReadRole:

--- a/src/tasksmodel.cpp
+++ b/src/tasksmodel.cpp
@@ -43,7 +43,7 @@ QVariant TasksModel::data(const QModelIndex &index, int role) const
     case Qt::DisplayRole: {
         switch (index.column()) {
         case 0:
-            return taskToTimeEmojies(task) + task.task_id;
+            return task.task_id + taskToTimeEmojies(task);
         case 1:
             return task.project.get();
         case 2:
@@ -54,6 +54,8 @@ QVariant TasksModel::data(const QModelIndex &index, int role) const
         }
         break;
     }
+    case Qt::TextAlignmentRole:
+        return { Qt::AlignVCenter | Qt::AlignLeft };
     case Qt::DecorationRole:
         if (index.column() == 0) {
             return (m_tasks.at(index.row()).active)

--- a/src/tasksmodel.hpp
+++ b/src/tasksmodel.hpp
@@ -5,6 +5,7 @@
 #include <QColor>
 #include <QList>
 #include <QModelIndex>
+#include <QTimer>
 #include <QVariant>
 #include <QtCore/Qt>
 
@@ -49,6 +50,7 @@ class TasksModel : public QAbstractTableModel {
 
   private:
     QList<DetailedTaskInfo> m_tasks;
+    QTimer *m_refresh_emoji_timer;
 };
 
 #endif // TASKSMODEL_HPP

--- a/src/tasksview.cpp
+++ b/src/tasksview.cpp
@@ -31,15 +31,6 @@ void TasksView::mousePressEvent(QMouseEvent *event)
 
     const auto idx = indexAt(event->pos());
 
-    // Enable "stop" button if the selected task is active
-    if (idx.isValid() && event->buttons() & Qt::LeftButton) {
-        const auto task_opt = qobject_cast<TasksModel *>(model())->getTask(idx);
-        if (task_opt.isValid()) {
-            const auto task = task_opt.value<DetailedTaskInfo>();
-            emit selectedTaskIsActive(task.active);
-        }
-    }
-
     // Right click to the "project" column will push it to taskwarrior filter
     if (idx.isValid() && idx.column() == project_column &&
         event->buttons() & Qt::RightButton) {

--- a/src/tasksview.hpp
+++ b/src/tasksview.hpp
@@ -18,7 +18,6 @@ class TasksView : public QTableView {
     void mouseReleaseEvent(QMouseEvent *event) override;
 
   signals:
-    void selectedTaskIsActive(bool is_active);
     void pushProjectFilter(const QString &);
     void linkActivated(const QString &link);
     void linkHovered(const QString &link);

--- a/src/taskwarrior.cpp
+++ b/src/taskwarrior.cpp
@@ -46,17 +46,17 @@ bool Taskwarrior::addTask(DetailedTaskInfo &task)
         [this, &task]() { return task.execAddNewTask(*m_executor); });
 }
 
-bool Taskwarrior::startTask(const QString &id)
+bool Taskwarrior::startTasks(const QList<DetailedTaskInfo> &tasks)
 {
-    return execCommandAndAccountUndo([this, &id]() {
-        return BatchTasksManager({ id }).execStartTask(*m_executor);
+    return execCommandAndAccountUndo([this, &tasks]() {
+        return BatchTasksManager(tasks).execStartTask(*m_executor);
     });
 }
 
-bool Taskwarrior::stopTask(const QString &id)
+bool Taskwarrior::stopTasks(const QList<DetailedTaskInfo> &tasks)
 {
-    return execCommandAndAccountUndo([this, &id]() {
-        return BatchTasksManager({ id }).execStopTask(*m_executor);
+    return execCommandAndAccountUndo([this, &tasks]() {
+        return BatchTasksManager(tasks).execStopTask(*m_executor);
     });
 }
 

--- a/src/taskwarrior.hpp
+++ b/src/taskwarrior.hpp
@@ -45,8 +45,8 @@ class Taskwarrior {
     }
 
     bool addTask(DetailedTaskInfo &task);
-    bool startTask(const QString &id);
-    bool stopTask(const QString &id);
+    bool startTasks(const QList<DetailedTaskInfo> &tasks);
+    bool stopTasks(const QList<DetailedTaskInfo> &tasks);
     bool editTask(DetailedTaskInfo &task);
     bool setPriority(const QString &id, DetailedTaskInfo::Priority);
     [[nodiscard]] std::optional<DetailedTaskInfo> getTask(const QString &id);


### PR DESCRIPTION
Add status emoji to tasks' table and tooltip.
"Working" image is replaced by "working" emoji for consistence.
Fixed states tracking for start/stop buttons.
Now start/stop buttons may operate on multiply rows selected.
Changed how tags will be shown in tooltip.
<img width="542" height="224" alt="image" src="https://github.com/user-attachments/assets/a368ce4c-a5c1-45e1-bac1-66a31127d0ba" />
<img width="515" height="242" alt="image" src="https://github.com/user-attachments/assets/189152c5-3f94-4d9c-aad4-d80d46bf4fba" />
<img width="514" height="234" alt="image" src="https://github.com/user-attachments/assets/699e8916-637b-4b45-8101-48d65e264d46" />



Note, version is changed to 1.2.0, please update Arch-Linux installer too.
