### PR TITLE
Fix visual priorities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(qtask CXX)
 
 set(QTASK_VERSION_MAJOR 1) # something big added / changed
 set(QTASK_VERSION_MINOR 2) # new small feature added
-set(QTASK_VERSION_PATCH 2) # refactor/bug fix inside current minor
+set(QTASK_VERSION_PATCH 3) # refactor/bug fix inside current minor
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/src/task_emojies.hpp
+++ b/src/task_emojies.hpp
@@ -22,11 +22,12 @@ class StatusEmoji {
         None = 0,
         Future,
         WaitPast,
-        DueApproaching,
-        SchedApproaching,
-        SchedPast, // 🚀
-        Active,    // 🔵
-        Overdue    // 🔥
+        DueApproaching,   // We assume Due is something strategical (long time).
+        Active,           // 🔵
+        SchedApproaching, // We assume Sched is something "tactical" (short
+                          // time)
+        SchedPast,        // 🚀
+        Overdue           // 🔥
     };
 
     explicit StatusEmoji(DetailedTaskInfo task,
@@ -80,11 +81,6 @@ class StatusEmoji {
             return EmojiUrgency::Overdue;
         }
 
-        // Working on something...
-        if (isSpecialSched()) {
-            return EmojiUrgency::Active;
-        }
-
         // Something was scheduled and it is in the past now.
         if (task.sched.get().has_value() &&
             task.sched.get().relationToNow(now) == DatesRelation::Past) {
@@ -95,6 +91,11 @@ class StatusEmoji {
         if (task.sched.get().has_value() &&
             task.sched.get().relationToNow(now) == DatesRelation::Approaching) {
             return EmojiUrgency::SchedApproaching;
+        }
+
+        // Working on something...
+        if (isSpecialSched()) {
+            return EmojiUrgency::Active;
         }
 
         // Coming soon deadline.

--- a/src/task_emojies.hpp
+++ b/src/task_emojies.hpp
@@ -58,9 +58,6 @@ class StatusEmoji {
     [[nodiscard]]
     QString schedEmoji() const
     {
-        if (isSpecialSched()) {
-            return hasEmoji() ? QString::fromUtf8("🔵") : "[W]";
-        }
         if (task.sched.get().has_value()) {
             return relationToEmoji(task.sched.get(), now);
         }
@@ -75,6 +72,11 @@ class StatusEmoji {
 
     [[nodiscard]] EmojiUrgency getMostUrgentLevel() const
     {
+        // Working on something...
+        if (isSpecialSched()) {
+            return EmojiUrgency::Active;
+        }
+
         // Highest priority - missing deadline.
         if (task.due.get().has_value() &&
             task.due.get().relationToNow(now) == DatesRelation::Past) {
@@ -91,11 +93,6 @@ class StatusEmoji {
         if (task.sched.get().has_value() &&
             task.sched.get().relationToNow(now) == DatesRelation::Approaching) {
             return EmojiUrgency::SchedApproaching;
-        }
-
-        // Working on something...
-        if (isSpecialSched()) {
-            return EmojiUrgency::Active;
         }
 
         // Coming soon deadline.

--- a/src/taskstatusesdelegate.cpp
+++ b/src/taskstatusesdelegate.cpp
@@ -25,10 +25,7 @@ QString makeAlignedCombinedEmoji(const StatusEmoji &status)
         return QString::fromUtf8("\u2003");
     };
 
-    // Order is important for UI/UX reason, it should match tooltip & fields in
-    // editor.
-    return wrap(status.schedEmoji()) + wrap(status.dueEmoji()) +
-           wrap(status.waitEmoji());
+    return wrap(StatusEmoji::urgencyToEmoji(status.getMostUrgentLevel()));
 }
 } // namespace
 


### PR DESCRIPTION
Fix / Update of the priorities shown in tray. Now "working" is shown if nothing scheduled is coming.
Changed table to show hottest status, with detailed explanation in tooltip:
<img width="504" height="219" alt="image" src="https://github.com/user-attachments/assets/e61d852d-920a-45dc-a66c-f2aa4b22df13" />
