### PR TITLE
Read UUID

### DIFF
--- a/src/filteredtaskslistreader.cpp
+++ b/src/filteredtaskslistreader.cpp
@@ -59,6 +59,13 @@ FilteredTasksListReader::getSchema() const
             },
         },
         {
+            "uuid",
+            [](const QString &v, Task &t, Mode m) {
+                SKIP_CONTINUATION;
+                t.task_uuid = v.trimmed();
+            },
+        },
+        {
             "start.active",
             [](const QString &v, Task &t, Mode m) {
                 SKIP_CONTINUATION;

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -132,10 +132,6 @@ MainWindow::MainWindow()
 
     connect(m_data_model, &TasksModel::globalUrgencyChanged, m_tray_icon,
             &SystemTrayIcon::updateStatusIcon);
-
-    m_data_model->refreshModel();
-
-    QTimer::singleShot(5000, this, &MainWindow::onApplyFilter);
 }
 
 MainWindow::~MainWindow() { m_task_provider.reset(); }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -39,6 +39,7 @@
 #include "settingsdialog.hpp"
 #include "tagsedit.hpp"
 #include "task.hpp"
+#include "task_ids_providers.hpp"
 #include "taskdescriptiondelegate.hpp"
 #include "taskdialog.hpp"
 #include "taskhintproviderdelegate.hpp"
@@ -85,7 +86,11 @@ MainWindow::MainWindow()
     , m_toolbar_actions(*m_task_toolbar)
     , m_task_provider(std::make_shared<Taskwarrior>())
     , m_data_model(new TasksModel(
-          m_task_provider, [this]() { return getSelectedTaskIds(); }, this))
+          m_task_provider,
+          [this]() {
+              return tasksListToIds(getSelectedTaskInModel(), kTaskUuidGetter);
+          },
+          this))
 
 {
     if (!m_task_provider->init()) {
@@ -362,7 +367,7 @@ void MainWindow::connectTaskToolbarActions()
             new DateTimeDialog(QDateTime::currentDateTime().addDays(1), this);
         dlg->open();
         QObject::connect(dlg, &QDialog::accepted, [this, dlg]() {
-            if (m_task_provider->waitTask(getSelectedTaskIds(),
+            if (m_task_provider->waitTask(getSelectedTaskShortIds(),
                                           dlg->getDateTime())) {
                 m_data_model->refreshIfChangedOnDisk();
             }
@@ -509,18 +514,18 @@ void MainWindow::closeEvent(QCloseEvent *event)
     }
 }
 
-std::optional<QString> MainWindow::getSelectedTaskId() const
+std::optional<QString> MainWindow::getSelectedTaskShortId() const
 {
-    const auto sel = getSelectedTaskIds();
+    const auto sel = getSelectedTaskShortIds();
     if (sel.empty()) {
         return std::nullopt;
     }
     return sel.front();
 }
 
-QStringList MainWindow::getSelectedTaskIds() const
+QStringList MainWindow::getSelectedTaskShortIds() const
 {
-    return tasksListToIds(getSelectedTaskInModel());
+    return tasksListToIds(getSelectedTaskInModel(), kTaskIdShortGetter);
 }
 
 QList<DetailedTaskInfo> MainWindow::getSelectedTaskInModel() const
@@ -602,7 +607,7 @@ void MainWindow::onAddTask()
 
 void MainWindow::onDeleteTasks()
 {
-    const auto selectedTasks = getSelectedTaskIds();
+    const auto selectedTasks = getSelectedTaskShortIds();
     const auto selectedCount = selectedTasks.size();
     if (selectedCount == 0) {
         return;
@@ -625,7 +630,7 @@ void MainWindow::onSetTasksDone()
     if (!m_tasks_view->selectionModel()->hasSelection()) {
         return;
     }
-    m_task_provider->setTaskDone(getSelectedTaskIds());
+    m_task_provider->setTaskDone(getSelectedTaskShortIds());
     m_tasks_view->selectionModel()->clearSelection();
     m_data_model->refreshIfChangedOnDisk();
 }
@@ -654,7 +659,7 @@ void MainWindow::onEnterTaskCommand()
 
 void MainWindow::showEditTaskDialog([[maybe_unused]] const QModelIndex &idx)
 {
-    const auto id_opt = getSelectedTaskId();
+    const auto id_opt = getSelectedTaskShortId();
     if (!id_opt) {
         m_data_model->refreshIfChangedOnDisk();
         return;

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -58,8 +58,8 @@ class MainWindow : public QMainWindow {
     void changeEvent(QEvent *) override;
     void closeEvent(QCloseEvent *event) override;
 
-    [[nodiscard]] std::optional<QString> getSelectedTaskId() const;
-    [[nodiscard]] QStringList getSelectedTaskIds() const;
+    [[nodiscard]] std::optional<QString> getSelectedTaskShortId() const;
+    [[nodiscard]] QStringList getSelectedTaskShortIds() const;
     [[nodiscard]] QList<DetailedTaskInfo> getSelectedTaskInModel() const;
   public slots:
     /// Add entry to tags filter

--- a/src/split_string.hpp
+++ b/src/split_string.hpp
@@ -28,7 +28,7 @@ struct SplitString {
             const QRegularExpressionMatch match = kSplitRx.match(line);
             if (match.hasMatch()) {
                 key = match.captured(1).simplified();
-                value = match.captured(2).simplified();
+                value = match.captured(2).trimmed();
             }
         }
     }

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -180,6 +180,7 @@ class InformationResponseSetters {
             void (InformationResponseSetters::*)(const SplitString &);
         const std::unordered_map<QString, handler_t> kTagToHandler = {
             { "ID", &InformationResponseSetters::handleID },
+            { "UUID", &InformationResponseSetters::handleUUID },
             { "Project", &InformationResponseSetters::handleProject },
             { "Priority", &InformationResponseSetters::handlePriority },
             { "Tags", &InformationResponseSetters::handleTags },
@@ -202,6 +203,7 @@ class InformationResponseSetters {
 
     // Handlers for each key.
     void handleID(const SplitString &line) { task.task_id = line.value; }
+    void handleUUID(const SplitString &line) { task.task_uuid = line.value; }
     void handleProject(const SplitString &line) { task.project = line.value; }
     void handleStart(const SplitString &) { task.active = true; }
     void handlePriority(const SplitString &line)

--- a/src/task.cpp
+++ b/src/task.cpp
@@ -6,7 +6,7 @@
 #include "split_string.hpp"
 #include "tabular_stencil_base.hpp"
 #include "task_date_time.hpp"
-#include "task_table_stencil.hpp"
+#include "task_ids_providers.hpp"
 #include "taskwarriorexecutor.hpp"
 
 #include <QDateTime>
@@ -481,7 +481,7 @@ bool DetailedTaskInfo::isFullRead() const
 }
 
 BatchTasksManager::BatchTasksManager(const QList<DetailedTaskInfo> &tasks)
-    : BatchTasksManager(tasksListToIds(tasks))
+    : BatchTasksManager(tasksListToIds(tasks, kTaskIdShortGetter))
 {
 }
 

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -121,15 +121,15 @@ class DetailedTaskInfo {
 
 Q_DECLARE_METATYPE(DetailedTaskInfo)
 
-template <typename taTasksContainer>
-QStringList tasksListToIds(const taTasksContainer &tasks)
+template <typename taTasksContainer, typename taTaskIdGetter>
+QStringList tasksListToIds(const taTasksContainer &tasks,
+                           const taTaskIdGetter &idGetter)
 {
     QStringList ids;
     ids.reserve(static_cast<qsizetype>(
         std::distance(std::begin(tasks), std::end(tasks))));
-    std::transform(
-        std::begin(tasks), std::end(tasks), std::back_inserter(ids),
-        [](const DetailedTaskInfo &task) -> QString { return task.task_id; });
+    std::transform(std::begin(tasks), std::end(tasks), std::back_inserter(ids),
+                   idGetter);
     return ids;
 }
 

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -37,9 +37,13 @@ class DetailedTaskInfo {
     enum class Priority : std::uint8_t { Unset, L, M, H }; // TODO: properties
     static Priority priorityFromString(const QString &p);
 
-    // task_id is special, it is always used explicit, so we do not need to
-    // track modification.
+    // task_id and task_uuid are special, it is always used explicit, so we do
+    // not need to track modification.
+    // task_id is numeric ID currently assigned to task, it can be changed by
+    // taskwarriror on ins/del operations.
     QString task_id;
+    // task_uuid is unique long id, it must remain the same always (I guess).
+    QString task_uuid;
 
     // Note, update TASK_PROPERTIES_LIST macros if you add/remove some
     // here.

--- a/src/task_ids_providers.hpp
+++ b/src/task_ids_providers.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "task.hpp"
+
+#include <functional>
+
+/// @brief Usable in cases when we need current task short ID.
+inline static const auto kTaskIdShortGetter =
+    std::mem_fn(&DetailedTaskInfo::task_id);
+
+/// @brief Unique, never changing long UUID. Usable in cases, like restore
+/// selection after full reaload when short IDs could be changed external.
+inline static const auto kTaskUuidGetter =
+    std::mem_fn(&DetailedTaskInfo::task_uuid);

--- a/src/tasksmodel.cpp
+++ b/src/tasksmodel.cpp
@@ -111,6 +111,9 @@ TasksModel::TasksModel(std::shared_ptr<Taskwarrior> task_provider,
     connect(&m_urgency_signaler, &QTimer::timeout, this, recomputeUrgency);
     connect(&ConfigManager::config().notifier(), &ConfigEvents::settingsChanged,
             this, recomputeUrgency);
+
+    // Need to trigger watcher at least once.
+    m_task_watcher->checkNow();
 }
 
 int TasksModel::rowCount(const QModelIndex & /*parent*/) const

--- a/src/tasksmodel.cpp
+++ b/src/tasksmodel.cpp
@@ -27,6 +27,7 @@
 
 #include "task.hpp"
 #include "task_emojies.hpp"
+#include "task_ids_providers.hpp"
 
 namespace
 {
@@ -257,9 +258,7 @@ void TasksModel::refreshModel()
         if (!task.isValid() || !task.canConvert<DetailedTaskInfo>()) {
             continue;
         }
-        // FIXME: need stable UUID here instead task_id.
-        // TODO:  switch to `task rc.json.array=on export` instead console.
-        const auto taskUuid = task.value<DetailedTaskInfo>().task_id;
+        const auto &taskUuid = kTaskUuidGetter(task.value<DetailedTaskInfo>());
         if (currentlySelectedTaskIds.contains(taskUuid)) {
             indicesToSelect.append(newIndex);
         }

--- a/src/tasksmodel.hpp
+++ b/src/tasksmodel.hpp
@@ -5,6 +5,7 @@
 #include <QColor>
 #include <QList>
 #include <QModelIndex>
+#include <QStringList>
 #include <QTimer>
 #include <QVariant>
 #include <QtCore/Qt>


### PR DESCRIPTION
Fix just found bug, I forgot to start external watcher after latest updates.

Added UUID reading and "restore selection" is bound to UUID now, so if ID was changed external it will select proper tasks still.
