### PR TITLE
Changed createPereodicAsynExec() to use chrono units to avoid errors

### DIFF
--- a/src/pereodic_async_executor.hpp
+++ b/src/pereodic_async_executor.hpp
@@ -38,7 +38,8 @@ class PereodicAsynExec : public IPereodicExec {
     using ReturnType = std::decay_t<decltype(std::apply(
         std::declval<taPereodicCallable>(), std::declval<ParamsTuple>()))>;
 
-    PereodicAsynExec(const int kCheckPeriodMs, taPereodicCallable callable,
+    PereodicAsynExec(const std::chrono::milliseconds kCheckPeriod,
+                     taPereodicCallable callable,
                      taPereodicParamsProvider params_provider,
                      taResultReceiver receiver)
         : m_callable(std::move(callable))
@@ -64,7 +65,7 @@ class PereodicAsynExec : public IPereodicExec {
          * databases.
          */
         m_timer.setSingleShot(true);
-        m_timer.setInterval(kCheckPeriodMs);
+        m_timer.setInterval(kCheckPeriod.count());
         QObject::connect(&m_timer, &QTimer::timeout, &m_timer,
                          [this]() { execNow(); });
 
@@ -142,8 +143,8 @@ class PereodicAsynExec : public IPereodicExec {
 /// @brief Factory function for the PereodicAsynExec.
 /// @returns std::unique_ptr<PereodicAsynExec<C, P, R>>
 template <typename C, typename P, typename R>
-auto createPereodicAsynExec(const std::chrono::milliseconds ms, C c, P p, R r)
+auto createPereodicAsynExec(std::chrono::milliseconds ms, C c, P p, R r)
 {
     return std::make_unique<PereodicAsynExec<C, P, R>>(
-        ms.count(), std::move(c), std::move(p), std::move(r));
+        ms, std::move(c), std::move(p), std::move(r));
 }

--- a/src/pereodic_async_executor.hpp
+++ b/src/pereodic_async_executor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <tuple>
 #include <type_traits>
 
@@ -141,8 +142,8 @@ class PereodicAsynExec : public IPereodicExec {
 /// @brief Factory function for the PereodicAsynExec.
 /// @returns std::unique_ptr<PereodicAsynExec<C, P, R>>
 template <typename C, typename P, typename R>
-auto createPereodicAsynExec(int ms, C c, P p, R r)
+auto createPereodicAsynExec(const std::chrono::milliseconds ms, C c, P p, R r)
 {
     return std::make_unique<PereodicAsynExec<C, P, R>>(
-        ms, std::move(c), std::move(p), std::move(r));
+        ms.count(), std::move(c), std::move(p), std::move(r));
 }

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -9,6 +9,7 @@
 #include <QString>
 
 #include <cassert>
+#include <chrono>
 #include <optional>
 #include <tuple>
 #include <utility>
@@ -19,7 +20,7 @@ using namespace std::chrono_literals;
 
 ///  @brief How often at most we will check for new data.
 // TODO: add config settings in UI instead.
-constexpr int kCheckPeriod = 10000;
+constexpr std::chrono::milliseconds kCheckPeriod = 10s; // NOLINT
 
 } // namespace
 

--- a/src/update_tray_icon_watcher.cpp
+++ b/src/update_tray_icon_watcher.cpp
@@ -213,13 +213,9 @@ UpdateTrayIconWatcher::UpdateTrayIconWatcher(QObject *parent)
     };
 
     // Setup async DB poll.
-    static constexpr int kCheckPeriod =
-        std::chrono::duration_cast<std::chrono::milliseconds>(
-            kRefreshFromDbInterval)
-            .count();
     m_pereodic_worker = createPereodicAsynExec(
-        kCheckPeriod, std::move(threadBody), std::move(paramsForThread),
-        std::move(receiverFromThread));
+        kRefreshFromDbInterval, std::move(threadBody),
+        std::move(paramsForThread), std::move(receiverFromThread));
 
     // Setup icon updater based on last poll.
     connect(&ConfigManager::config().notifier(), &ConfigEvents::settingsChanged,

--- a/tests/pereodic_async_executor_test.cpp
+++ b/tests/pereodic_async_executor_test.cpp
@@ -2,6 +2,7 @@
 #include "qt_base_test.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <tuple>
 
 #include <QEventLoop>
@@ -10,6 +11,7 @@
 #include <gtest/gtest.h>
 
 using namespace ::testing;
+using namespace std::chrono_literals;
 
 class PereodicAsynExecTest : public QtBaseTest {};
 
@@ -25,7 +27,7 @@ TEST_F(PereodicAsynExecTest, SimpleExecutionFlow)
         loop.quit();
     };
 
-    PereodicAsynExec exec(1000, callable, provider, receiver);
+    PereodicAsynExec exec(1000ms, callable, provider, receiver);
     exec.execNow();
     loop.exec();
     EXPECT_EQ(callCount, 1);
@@ -49,7 +51,7 @@ TEST_F(PereodicAsynExecTest, PeriodicRestart)
         }
     };
 
-    PereodicAsynExec exec(10, callable, provider, receiver);
+    PereodicAsynExec exec(10ms, callable, provider, receiver);
     exec.execNow();
     loop.exec();
 
@@ -72,7 +74,7 @@ TEST_F(PereodicAsynExecTest, AvoidsOverlapping)
     auto provider = []() { return std::make_tuple(1); };
     auto receiver = [&](int) { loop.quit(); };
 
-    PereodicAsynExec exec(10, callable, provider, receiver);
+    PereodicAsynExec exec(10ms, callable, provider, receiver);
 
     exec.execNow();
     QThread::msleep(100);
@@ -96,7 +98,7 @@ TEST_F(PereodicAsynExecTest, DestructorSafety)
     auto provider = []() { return std::make_tuple(1); };
     auto receiver = [](int) { /* Nothing*/ };
     {
-        PereodicAsynExec exec(100, callable, provider, receiver);
+        PereodicAsynExec exec(100ms, callable, provider, receiver);
         exec.execNow();
 
         // Wait while thread is started.

--- a/tests/tabular_stencil_base_test.cpp
+++ b/tests/tabular_stencil_base_test.cpp
@@ -76,7 +76,6 @@ TEST_F(TabularParserTest, HandlesSimpleOutput)
         "ID  Proj Desc",         // Header (skipped by kHeadersSize)
         "1   Work Buy milk",     // Data 1
         "2   Home Clean room",   // Data 2
-        "2 tasks"                // Footer (skipped by kFooterSize)
     };
 
     auto result = spy.parseConsoleOutput(schema, stencil, mockOutput);
@@ -92,14 +91,14 @@ TEST_F(TabularParserTest, HandlesMultilineContinuation)
     TableStencil stencil({ "ID", "Proj", "Desc" });
     ASSERT_TRUE(stencil.processLabelString("----|----|-----------"));
 
-    const QStringList mockOutput = { "----|----|-----------", // labels
-                                     "ID  Proj Desc",         // header
-                                     "1   Work Long task",
-                                     "         description", // continuation 1
-                                     "         part two", // continuation 2 more
-                                     "2   Home Next task",
-
-                                     "1 task" };
+    const QStringList mockOutput = {
+        "----|----|-----------", // labels
+        "ID  Proj Desc",         // header
+        "1   Work Long task",
+        "         description", // continuation 1
+        "         part two",    // continuation 2 more
+        "2   Home Next task",
+    };
 
     auto result = spy.parseConsoleOutput(schema, stencil, mockOutput);
 
@@ -114,13 +113,14 @@ TEST_F(TabularParserTest, SkipsEmptyLines)
     TableStencil stencil({ "ID", "Proj", "Desc" });
     ASSERT_TRUE(stencil.processLabelString("----|----|-----------"));
 
-    const QStringList mockOutput = { "----|----|-----------", // Markers
-                                     "ID  Proj Desc",         // Header
-                                     "1   Work Task 1",
-                                     " ",    // Empty line to ignore
-                                     "    ", // Spaces line to ignore
-                                     "2   Home Task 2",
-                                     "2 tasks" };
+    const QStringList mockOutput = {
+        "----|----|-----------", // Markers
+        "ID  Proj Desc",         // Header
+        "1   Work Task 1",
+        " ",    // Empty line to ignore
+        "    ", // Spaces line to ignore
+        "2   Home Task 2",
+    };
 
     auto result = spy.parseConsoleOutput(schema, stencil, mockOutput);
 
@@ -136,10 +136,12 @@ TEST_F(TabularParserTest, HandlesImpossibleContinuationGracefully)
 
     // Ситуация: вывод начинается сразу с продолжения (ID пуст на первой строке
     // данных)
-    const QStringList mockOutput = { "----|----|-----------", // labels
-                                     "ID  Proj Desc",         // headers
-                                     "         Broken task",  // broken output
-                                     "2   Home Valid task", "1 task" };
+    const QStringList mockOutput = {
+        "----|----|-----------", // labels
+        "ID  Proj Desc",         // headers
+        "         Broken task",  // broken output
+        "2   Home Valid task",
+    };
 
     auto result = spy.parseConsoleOutput(schema, stencil, mockOutput);
 


### PR DESCRIPTION
Changed function `createPereodicAsynExec(...)` prototype to accept `chrono` units instead plain `int` to avoid errors later.

Fixed `TabularParserTest` test, as expected output from taskwarrior was changed recently.
