### PR TITLE
Validate undo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(qtask CXX)
 
 set(QTASK_VERSION_MAJOR 1) # something big added / changed
 set(QTASK_VERSION_MINOR 2) # new small feature added
-set(QTASK_VERSION_PATCH 5) # refactor/bug fix inside current minor
+set(QTASK_VERSION_PATCH 6) # refactor/bug fix inside current minor
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/src/mainwindow.hpp
+++ b/src/mainwindow.hpp
@@ -23,6 +23,7 @@
 #include <qtypes.h>
 
 #include "tagsedit.hpp"
+#include "task.hpp"
 #include "tasksmodel.hpp"
 #include "tasksview.hpp"
 #include "taskwarrior.hpp"
@@ -52,7 +53,7 @@ class MainWindow : public QMainWindow {
     void initShortcuts();
     void connectTaskToolbarActions();
     void toggleMainWindow();
-    void onOpenSettings();
+    void onOpenSettings(bool exitAppToo);
     void quitApp();
 
     bool eventFilter(QObject *watched, QEvent *event) override;

--- a/src/task.hpp
+++ b/src/task.hpp
@@ -196,6 +196,12 @@ class TaskWarriorDbState {
         return this->fields != other.fields;
     }
 
+    [[nodiscard]]
+    ulong getUndoCount() const
+    {
+        return fields.fieldUndo;
+    }
+
     /// @returns std::nullopt if it was error reading stats or current state of
     /// TaskWarrior's data base as TaskWarriorDbState.
     /// @note We select only fields we think can help us to detect modifications

--- a/src/tasksmodel.cpp
+++ b/src/tasksmodel.cpp
@@ -29,7 +29,9 @@
 #include "task_emojies.hpp"
 #include "task_ids_providers.hpp"
 #include "tasksstatuseswatcher.hpp"
+#include "taskwarrior.hpp"
 #include "taskwatcher.hpp"
+#include "undo_tracker.hpp"
 #include "update_tray_icon_watcher.hpp"
 
 namespace
@@ -62,12 +64,12 @@ QColor getColorForPriority(DetailedTaskInfo::Priority priority)
         return base;
     }
     const bool isDark = base.value() < 128;
-    const qreal factor = isDark ? 0.15 : 0.25;
+    const float factor = isDark ? 0.15f : 0.25f;
 
     return QColor::fromRgbF(
-        base.redF() * (1.0 - factor) + tint.redF() * factor,
-        base.greenF() * (1.0 - factor) + tint.greenF() * factor,
-        base.blueF() * (1.0 - factor) + tint.blueF() * factor);
+        base.redF() * (1.0f - factor) + tint.redF() * factor,
+        base.greenF() * (1.0f - factor) + tint.greenF() * factor,
+        base.blueF() * (1.0f - factor) + tint.blueF() * factor);
 }
 } // namespace
 
@@ -223,6 +225,12 @@ QColor TasksModel::rowColor(const int row) const
         return getColorForPriority(DetailedTaskInfo::Priority::Unset);
     }
     return getColorForPriority(m_tasks.at(row).priority.get());
+}
+
+void TasksModel::initUndoSupport()
+{
+    connect(m_task_watcher, &TaskWatcher::dataOnDiskWereChangedWithUndoCount,
+            &m_task_provider->getActionsCounter(), &UndoTracker::newDbReading);
 }
 
 void TasksModel::refreshModel()

--- a/src/tasksmodel.hpp
+++ b/src/tasksmodel.hpp
@@ -52,6 +52,7 @@ class TasksModel : public QAbstractTableModel {
 
     [[nodiscard]] QColor rowColor(int row) const;
 
+    void initUndoSupport();
   signals:
     /// @brief View can listen this signal if it wants to restore selection
     /// after model reset.

--- a/src/taskwarrior.cpp
+++ b/src/taskwarrior.cpp
@@ -34,7 +34,7 @@ bool Taskwarrior::init()
 {
     const auto &binary = ConfigManager::config().get(ConfigManager::TaskBin);
     try {
-        m_executor = std::make_unique<TaskWarriorExecutor>(binary);
+        m_executor = std::make_shared<TaskWarriorExecutor>(binary);
         return true;
     } catch (std::exception &e) {
         std::cerr << e.what() << std::endl;

--- a/src/taskwarrior.hpp
+++ b/src/taskwarrior.hpp
@@ -85,7 +85,7 @@ class Taskwarrior {
     /// @brief Counter of changes in the taskwarrior database that can be
     /// undone.
     size_t m_actions_counter;
-    std::unique_ptr<TaskWarriorExecutor> m_executor;
+    std::shared_ptr<TaskWarriorExecutor> m_executor;
     AllAtOnceKeywordsFinder m_filter;
 };
 

--- a/src/taskwatcher.cpp
+++ b/src/taskwatcher.cpp
@@ -7,6 +7,7 @@
 
 #include <QObject>
 #include <QString>
+#include <qtmetamacros.h>
 
 #include <cassert>
 #include <optional>
@@ -30,8 +31,10 @@ TaskWatcher::TaskWatcher(QObject *parent)
     // then DB needs time to settle.
     delayedSignalSender.setSingleShot(true);
     delayedSignalSender.setInterval(150);
-    connect(&delayedSignalSender, &QTimer::timeout, this,
-            &TaskWatcher::dataOnDiskWereChanged);
+    connect(&delayedSignalSender, &QTimer::timeout, this, [this]() {
+        emit dataOnDiskWereChanged();
+        emit dataOnDiskWereChangedWithUndoCount(m_latestDbState.getUndoCount());
+    });
 
     auto threadBody = [](QString pathToBinary) -> TaskWarriorDbState::Optional {
         try {

--- a/src/taskwatcher.hpp
+++ b/src/taskwatcher.hpp
@@ -3,7 +3,9 @@
 
 #include <QObject>
 #include <QTimer>
+#include <qtmetamacros.h>
 
+#include <cstdint>
 #include <memory>
 
 #include "pereodic_async_executor.hpp"
@@ -21,7 +23,7 @@ class TaskWatcher : public QObject {
 
   signals:
     void dataOnDiskWereChanged();
-
+    void dataOnDiskWereChangedWithUndoCount(std::uint64_t currentUndoCount);
   public slots:
     void checkNow();
 

--- a/src/undo_tracker.cpp
+++ b/src/undo_tracker.cpp
@@ -70,7 +70,8 @@ bool UndoTracker::undo()
 
 void UndoTracker::sendSignalForUi()
 {
-    emit undoAvail(isSyncedCounter() && m_counter > 0);
+    const bool isEnabled = isSyncedCounter() && m_counter > 0;
+    emit undoAvail(isEnabled);
 }
 
 void UndoTracker::setVariablesByReading(std::uint64_t reading)

--- a/src/undo_tracker.cpp
+++ b/src/undo_tracker.cpp
@@ -1,0 +1,90 @@
+#include "undo_tracker.hpp"
+#include "exec_on_exit.hpp"
+#include "task.hpp"
+#include "taskwarriorexecutor.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include <QObject>
+#include <qtmetamacros.h>
+
+UndoTracker::UndoTracker(std::shared_ptr<TaskWarriorExecutor> executor,
+                         QObject *parent)
+    : QObject{ parent }
+    , m_counter{ 0u }
+    , m_base_value{ kInvalidBaseState }
+    , m_latest_db_reading{ kInvalidBaseState - 1 }
+    , m_executor(std::move(executor))
+{
+}
+
+void UndoTracker::startTracking()
+{
+    const exec_on_exit sendSignal([this]() { sendSignalForUi(); });
+    if (m_executor) {
+        const auto optState = TaskWarriorDbState::readCurrent(*m_executor);
+        if (optState) {
+            setVariablesByReading(optState->getUndoCount());
+            return;
+        }
+    }
+    setVariablesByReading(kInvalidBaseState);
+}
+
+void UndoTracker::newDbReading(const std::uint64_t undoCount)
+{
+    m_latest_db_reading = undoCount;
+    if (!isSyncedCounter()) {
+        setVariablesByReading(undoCount);
+        sendSignalForUi();
+    }
+}
+
+void UndoTracker::addUndo()
+{
+    // We need to increment m_latest_db_reading so sendSignalForUi() will not
+    // fail right now.
+    ++m_counter;
+    ++m_latest_db_reading;
+    sendSignalForUi();
+}
+
+bool UndoTracker::undo()
+{
+    if (!m_executor || m_counter == 0) {
+        return false;
+    }
+
+    const exec_on_exit sendSignal([this]() { sendSignalForUi(); });
+    if (isSyncedCounter() &&
+        m_executor->execTaskProgramWithDefaults({ "undo" })) {
+        --m_counter;
+        // Decrement, so sendSignalForUi() will not fail right now.
+        --m_latest_db_reading;
+        return true;
+    }
+    return false;
+}
+
+void UndoTracker::sendSignalForUi()
+{
+    emit undoAvail(isSyncedCounter() && m_counter > 0);
+}
+
+void UndoTracker::setVariablesByReading(std::uint64_t reading)
+{
+    m_counter = 0;
+    m_base_value = m_latest_db_reading = reading;
+}
+
+bool UndoTracker::isSyncedCounter() const
+{
+    // The logic is simple: what we see in the DB (latest_db_reading) must
+    // exactly match what we expect (base_value + our_local_changes).
+    // If they differ, an external process has modified the Taskwarrior
+    // database.
+    return m_base_value != kInvalidBaseState &&
+           m_latest_db_reading == m_base_value + m_counter;
+}

--- a/src/undo_tracker.hpp
+++ b/src/undo_tracker.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "taskwarriorexecutor.hpp"
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+
+#include <QObject>
+#include <qtmetamacros.h>
+
+/// @brief This class tracks undo counts. It uses value read from DB as base to
+/// see, if it was any external action. If it was than we cannot make own undo.
+class UndoTracker : public QObject {
+    Q_OBJECT
+  public:
+    explicit UndoTracker(std::shared_ptr<TaskWarriorExecutor> executor,
+                         QObject *parent = nullptr);
+
+    /// @returns true if we're in sync to DB and can do undos.
+    [[nodiscard]] bool isSyncedCounter() const;
+
+    UndoTracker &operator++()
+    {
+        addUndo();
+        return *this;
+    }
+  public slots:
+    /// @brief Reads current state of data base and uses it as base line for
+    /// accounting undos.
+    /// @note It must be called at least once after creation. It does actual DB
+    /// reading itself.
+    void startTracking();
+
+    /// @brief Other watchers should provide current undos count in DB (so we do
+    /// not introduce extra reading here).
+    /// Based on provided value we can decide if we can do own undo yet.
+    void newDbReading(std::uint64_t undoCount);
+
+    /// @brief It should be called when we did something, which increases undo
+    /// count.
+    void addUndo();
+
+    /// @brief Executes UNDO operation DB IF we can.
+    /// @returns true if undo was executed.
+    bool undo();
+  signals:
+    /// @brief signal UI if it should enable/disable undo controls.
+    void undoAvail(bool enabled);
+
+  private:
+    void sendSignalForUi();
+    void setVariablesByReading(std::uint64_t reading);
+
+    /// @brief The number of undoable actions performed by THIS session.
+    /// It tells us how many times we can safely call 'undo'.
+    std::uint64_t m_counter;
+    /// @brief The DB's undo count at the moment tracking started or was reset.
+    /// Used as a reference point to detect drift caused by external tools.
+    std::uint64_t m_base_value;
+    /// @brief The most recent known state of the DB's undo count.
+    /// It is updated either by real DB readings or "optimistically" by our
+    /// own addUndo/undo calls to prevent UI flicker during sync.
+    std::uint64_t m_latest_db_reading;
+
+    std::shared_ptr<TaskWarriorExecutor> m_executor;
+
+    static constexpr auto kInvalidBaseState =
+        std::numeric_limits<std::uint64_t>::max();
+};

--- a/src/undo_tracker.hpp
+++ b/src/undo_tracker.hpp
@@ -44,6 +44,7 @@ class UndoTracker : public QObject {
     /// @brief Executes UNDO operation DB IF we can.
     /// @returns true if undo was executed.
     bool undo();
+
   signals:
     /// @brief signal UI if it should enable/disable undo controls.
     void undoAvail(bool enabled);


### PR DESCRIPTION
## Problem

If changes are made both inside the app and externally (e.g., via scripts or CLI) simultaneously, the app's internal undo counter becomes invalid as it doesn't account for those external modifications.

## Solution

This PR introduces the `UndoTracker` class. It monitors the database state to ensure our local undo history stays in sync with the actual DB. If a de-sync is detected, the local undo counter is reset, as we cannot safely perform an "undo" past the de-sync point.

Additionally, if `Taskwarrior::init()` fails (e.g., version detection failure), the app now displays the settings dialog and exits upon closing, preventing the app from running in a broken state.