### PR TITLE
Fix compilation with latest compiler.

### DIFF
--- a/src/update_tray_icon_watcher.cpp
+++ b/src/update_tray_icon_watcher.cpp
@@ -34,9 +34,10 @@ constexpr T constexpr_min(const T a, Args... args)
     return constexpr_min(a, constexpr_min(args...));
 }
 
+constexpr std::chrono::milliseconds kDefaultRefresh = 5min; // NOLINT
+
 /// @brief Combined refresh interval of how often we will check status below.
-constexpr auto kRefreshFromDbInterval = []() {
-    static constexpr std::chrono::milliseconds kDefaultRefresh = 5min; // NOLINT
+constexpr auto kRefreshFromDbInterval = []() constexpr {
     return constexpr_min(
         kDefaultRefresh,
         TaskDateTime<ETaskDateTimeRole::Due>::warning_interval(),


### PR DESCRIPTION
`static` cannot be used inside `constexpr` functions until C++25, old compilers allowed that for some reason.